### PR TITLE
Cull viewmodel to render correctly in Xash3d

### DIFF
--- a/cl_dll/StudioModelRenderer.cpp
+++ b/cl_dll/StudioModelRenderer.cpp
@@ -2125,14 +2125,15 @@ void CStudioModelRenderer::StudioRenderFinal_Hardware( void )
 			IEngineStudio.GL_SetRenderMode( rendermode );
 
 			extern cvar_t *m_pCvarRighthand;
-			if (m_pCurrentEntity == gEngfuncs.GetViewModel() && !(m_pCvarRighthand->value)) {
+			extern qboolean g_fXashEngine;
+			if (m_pCurrentEntity == gEngfuncs.GetViewModel() && (!m_pCvarRighthand->value || g_fXashEngine)) {
 				gEngfuncs.pTriAPI->CullFace( TRI_NONE );
 			}
 
 			IEngineStudio.StudioDrawPoints();
 			IEngineStudio.GL_StudioDrawShadow();
 
-			if (m_pCurrentEntity == gEngfuncs.GetViewModel() && !(m_pCvarRighthand->value)) {
+			if (m_pCurrentEntity == gEngfuncs.GetViewModel() && (!m_pCvarRighthand->value || g_fXashEngine)) {
 				gEngfuncs.pTriAPI->CullFace( TRI_FRONT );
 			}
 		}

--- a/cl_dll/cdll_int.cpp
+++ b/cl_dll/cdll_int.cpp
@@ -50,6 +50,8 @@ cl_enginefunc_t gEngfuncs;
 CHud gHUD;
 TeamFortressViewport *gViewPort = NULL;
 
+qboolean g_fXashEngine = FALSE;
+
 
 #include "particleman.h"
 CSysModule *g_hParticleManModule = NULL;
@@ -155,6 +157,9 @@ int CL_DLLEXPORT Initialize( cl_enginefunc_t *pEnginefuncs, int iVersion )
 
 	EV_HookEvents();
 	CL_LoadParticleMan();
+
+	if (gEngfuncs.pfnGetCvarPointer("host_clientloaded") != NULL)
+		g_fXashEngine = TRUE;
 
 	// get tracker interface, if any
 	return 1;


### PR DESCRIPTION
Xash3d inverts viewmodel rendering. Correct it by culling.

<img width="640" alt="invert" src="https://user-images.githubusercontent.com/729372/140620944-fa7b2b04-a396-4c53-b236-18800590301b.png">

