### PR TITLE
Push mutators to client from server, disable mutators that don't make sense in MP or SP.

### DIFF
--- a/cl_dll/StudioModelRenderer.cpp
+++ b/cl_dll/StudioModelRenderer.cpp
@@ -1012,8 +1012,9 @@ void CStudioModelRenderer::StudioSetupBones ( void )
 			ConcatTransforms ((*m_plighttransform)[pbones[i].parent], bonematrix, (*m_plighttransform)[i]);
 		}
 
-		if (strstr(CVAR_GET_STRING("mp_mutators"), "dkmode") ||
-			atoi(CVAR_GET_STRING("mp_mutators")) == MUTATOR_DKMODE)
+		if (gHUD.szActiveMutators != NULL &&
+			(strstr(gHUD.szActiveMutators, "dkmode") ||
+			atoi(gHUD.szActiveMutators) == MUTATOR_DKMODE))
 		{
 			if (m_pCurrentEntity != gEngfuncs.GetViewModel())
 			{
@@ -1238,8 +1239,9 @@ int CStudioModelRenderer::StudioDrawModel( int flags )
 		m_fDoInterp = 0;
 		
 		// draw as though it were a player
-		if (strstr(CVAR_GET_STRING("mp_mutators"), "sanic") ||
-			atoi(CVAR_GET_STRING("mp_mutators")) == MUTATOR_SANIC)
+		if (gHUD.szActiveMutators != NULL &&
+			(strstr(gHUD.szActiveMutators, "sanic") ||
+			atoi(gHUD.szActiveMutators) == MUTATOR_SANIC))
 			result = 1;
 		else
 			result = StudioDrawPlayer( flags, &deadplayer );
@@ -1831,8 +1833,9 @@ StudioDrawPlayer
 */
 int CStudioModelRenderer::StudioDrawPlayer( int flags, entity_state_t *pplayer )
 {
-	if (strstr(CVAR_GET_STRING("mp_mutators"), "sanic") ||
-		atoi(CVAR_GET_STRING("mp_mutators")) == MUTATOR_SANIC)
+	if (gHUD.szActiveMutators != NULL &&
+		(strstr(gHUD.szActiveMutators, "sanic") ||
+		atoi(gHUD.szActiveMutators) == MUTATOR_SANIC))
 	{
 		static TEMPENTITY *t[32];
 		int c = pplayer->number - 1;
@@ -1979,8 +1982,9 @@ int CStudioModelRenderer::StudioDrawPlayer( int flags, entity_state_t *pplayer )
 			m_pCurrentEntity->curstate.body = 1; // force helmet
 		}
 
-		if (strstr(CVAR_GET_STRING("mp_mutators"), "santahat") ||
-			atoi(CVAR_GET_STRING("mp_mutators")) == MUTATOR_SANTAHAT)
+		if (gHUD.szActiveMutators != NULL &&
+			(strstr(gHUD.szActiveMutators, "santahat") ||
+			atoi(gHUD.szActiveMutators) == MUTATOR_SANTAHAT))
 			m_pCurrentEntity->curstate.body = 2;
 
 		lighting.plightvec = dir;

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -341,6 +341,11 @@ int __MsgFunc_PlayCSound(const char *pszName, int iSize, void *pbuf)
 	return gHUD.MsgFunc_PlayCSound(pszName, iSize, pbuf );
 }
 
+int __MsgFunc_Mutators(const char *pszName, int iSize, void *pbuf)
+{
+	return gHUD.MsgFunc_Mutators(pszName, iSize, pbuf );
+}
+
 // This is called every time the DLL is loaded
 void CHud :: Init( void )
 {
@@ -379,6 +384,7 @@ void CHud :: Init( void )
 
 	HOOK_MESSAGE( Acrobatics );
 	HOOK_MESSAGE( PlayCSound );
+	HOOK_MESSAGE( Mutators );
 
 	// VGUI Menus
 	HOOK_MESSAGE( VGUIMenu );

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -711,9 +711,11 @@ public:
 	void _cdecl MsgFunc_ViewMode( const char *pszName, int iSize, void *pbuf );
 	int _cdecl MsgFunc_SetFOV(const char *pszName,  int iSize, void *pbuf);
 	int  _cdecl MsgFunc_Concuss( const char *pszName, int iSize, void *pbuf );
-	
+
+	// Cold Ice Remastered
 	int  _cdecl MsgFunc_Acrobatics( const char *pszName, int iSize, void *pbuf );
 	int  _cdecl MsgFunc_PlayCSound( const char *pszName, int iSize, void *pbuf );
+	int  _cdecl MsgFunc_Mutators( const char *pszName, int iSize, void *pbuf );
 
 	// Screen information
 	SCREENINFO	m_scrinfo;
@@ -733,6 +735,8 @@ public:
 	void FlashHud();
 
 	crosspr_s crossspr;
+
+	char szActiveMutators[64];
 };
 
 extern CHud gHUD;

--- a/cl_dll/hud_msg.cpp
+++ b/cl_dll/hud_msg.cpp
@@ -220,3 +220,10 @@ int CHud :: MsgFunc_PlayCSound( const char *pszName, int iSize, void *pbuf )
 	}
 	return 1;
 }
+
+int CHud :: MsgFunc_Mutators( const char *pszName, int iSize, void *pbuf )
+{
+	BEGIN_READ( pbuf, iSize );
+	strncpy( gHUD.szActiveMutators, READ_STRING(), 64 );
+	return 1;
+}

--- a/cl_dll/input.cpp
+++ b/cl_dll/input.cpp
@@ -635,8 +635,9 @@ void CL_AdjustAngles ( float frametime, float *viewangles )
 
 	if (!(in_strafe.state & 1))
 	{
-		if (strstr(CVAR_GET_STRING("mp_mutators"), "topsyturvy") ||
-			atoi(CVAR_GET_STRING("mp_mutators")) == MUTATOR_TOPSYTURVY)
+		if (gHUD.szActiveMutators != NULL &&
+			(strstr(gHUD.szActiveMutators, "topsyturvy") ||
+			atoi(gHUD.szActiveMutators) == MUTATOR_TOPSYTURVY))
 		{
 			viewangles[YAW] += speed*cl_yawspeed->value*CL_KeyState (&in_right);
 			viewangles[YAW] -= speed*cl_yawspeed->value*CL_KeyState (&in_left);
@@ -659,8 +660,9 @@ void CL_AdjustAngles ( float frametime, float *viewangles )
 	up = CL_KeyState (&in_lookup);
 	down = CL_KeyState(&in_lookdown);
 	
-	if (strstr(CVAR_GET_STRING("mp_mutators"), "topsyturvy") ||
-	 	atoi(CVAR_GET_STRING("mp_mutators")) == MUTATOR_TOPSYTURVY)
+	if (gHUD.szActiveMutators != NULL &&
+		(strstr(gHUD.szActiveMutators, "topsyturvy") ||
+		atoi(gHUD.szActiveMutators) == MUTATOR_TOPSYTURVY))
 	{
 		viewangles[PITCH] += speed*cl_pitchspeed->value * up;
 		viewangles[PITCH] -= speed*cl_pitchspeed->value * down;

--- a/cl_dll/inputw32.cpp
+++ b/cl_dll/inputw32.cpp
@@ -416,8 +416,9 @@ void IN_ScaleMouse( float *x, float *y )
 	// This is the default sensitivity
 	float mouse_senstivity = ( gHUD.GetSensitivity() != 0 ) ? gHUD.GetSensitivity() : sensitivity->value;
 
-	if (strstr(CVAR_GET_STRING("mp_mutators"), "topsyturvy") ||
-		atoi(CVAR_GET_STRING("mp_mutators")) == MUTATOR_TOPSYTURVY)
+	if (gHUD.szActiveMutators != NULL &&
+		(strstr(gHUD.szActiveMutators, "topsyturvy") ||
+		atoi(gHUD.szActiveMutators) == MUTATOR_TOPSYTURVY))
 	{
 		mouse_senstivity *= -1;
 	}

--- a/cl_dll/view.cpp
+++ b/cl_dll/view.cpp
@@ -728,8 +728,9 @@ void V_CalcNormalRefdef ( struct ref_params_s *pparams )
 		}
 	}
 
-	if (strstr(CVAR_GET_STRING("mp_mutators"), "topsyturvy") ||
-		atoi(CVAR_GET_STRING("mp_mutators")) == MUTATOR_TOPSYTURVY)
+	if (gHUD.szActiveMutators != NULL &&
+		(strstr(gHUD.szActiveMutators, "topsyturvy") ||
+		atoi(gHUD.szActiveMutators) == MUTATOR_TOPSYTURVY))
 		view->angles[ROLL] = 180;
 
 #ifdef _DEBUG

--- a/dlls/gamerules.cpp
+++ b/dlls/gamerules.cpp
@@ -33,6 +33,7 @@ DLL_GLOBAL CGameRules*	g_pGameRules = NULL;
 extern DLL_GLOBAL BOOL	g_fGameOver;
 extern int gmsgDeathMsg;	// client dll messages
 extern int gmsgMOTD;
+extern int gmsgMutators;
 
 int g_teamplay = 0;
 
@@ -646,6 +647,11 @@ void CGameRules::CheckMutators(void)
 					CVAR_SET_FLOAT("sys_timescale", 1.0);
 			}
 		}
+
+		MESSAGE_BEGIN( MSG_BROADCAST, gmsgMutators );
+			WRITE_STRING( mutators.string );
+		MESSAGE_END();
+
 		m_flDetectedMutatorChange = 0;
 	}
 }

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -201,6 +201,7 @@ int gmsgAcrobatics = 0;
 int gmsgLifeBar = 0;
 int gmsgReceiveW = 0;
 int gmsgPlayClientSound = 0;
+int gmsgMutators = 0;
 
 void LinkUserMessages( void )
 {
@@ -252,6 +253,7 @@ void LinkUserMessages( void )
 	gmsgLifeBar = REG_USER_MSG("LifeBar", 3);
 	gmsgReceiveW = REG_USER_MSG("ReceiveW", 1);
 	gmsgPlayClientSound = REG_USER_MSG("PlayCSound", 1);
+	gmsgMutators = REG_USER_MSG("Mutators", -1);
 }
 
 LINK_ENTITY_TO_CLASS( player, CBasePlayer );

--- a/dlls/world.cpp
+++ b/dlls/world.cpp
@@ -71,6 +71,7 @@ extern DLL_GLOBAL const char *g_szMutators[] = {
 	"infiniteammo",
 	"randomweapon",
 	"speedup",
+	"maxpack",
 };
 
 extern void W_Precache(void);
@@ -766,6 +767,19 @@ void CWorld :: RandomizeMutators( void )
 	{
 		int index = RANDOM_LONG(1,(int)ARRAYSIZE(g_szMutators) - 1);
 		const char *tryIt = g_szMutators[index];
+
+		// Skip mutators that break multiplayer
+		if (g_pGameRules->IsMultiplayer())
+		{
+			if (strstr(tryIt, "slowmo") || strstr(tryIt, "speedup"))
+				continue;
+		}
+		else
+		{
+			if (strstr(tryIt, "maxpack"))
+				continue;
+		}
+
 		if (!strstr(result, tryIt))
 		{
 			if (strlen(result))


### PR DESCRIPTION
Direct cvar lookups caused crashing on clients. Removed this logic, and pushed mutators to the client appropriately.

Also, disable mutators that don't work well in either MP or SP game modes.

Finally, forgot the maxpack mutator in the randomizer.