### PR TITLE
Enable hud_fastswitch to cycle through available weapons in a slot

### DIFF
--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -453,23 +453,40 @@ void WeaponsResource :: SelectSlot( int iSlot, int fAdvance, int iDirection )
 	WEAPON *p = NULL;
 	bool fastSwitch = CVAR_GET_FLOAT( "hud_fastswitch" ) != 0;
 
+	if (fastSwitch)
+	{
+		// Switching between menus restarts count
+		if (gpLastSel && iSlot != gpLastSel->iSlot)
+			gpLastSel = NULL;
+
+		// No selection, start at top
+		if (!gpLastSel)
+			p = GetFirstPos( iSlot );
+		else
+		{
+			// Try next
+			p = GetNextActivePos( iSlot, gpLastSel->iSlotPos );
+			// End of list, start at top
+			if (!p)
+				p = GetFirstPos( iSlot );
+		}
+
+		// Found a weapon, store and switch
+		if (p)
+		{
+			PlaySound("wpn_select.wav", 1);
+			gpLastSel = p;
+			ServerCmd( p->szName );
+			g_weaponselect = p->iId;
+		}
+
+		return;
+	}
+
 	if ( (gpActiveSel == NULL) || (gpActiveSel == (WEAPON *)1) || (iSlot != gpActiveSel->iSlot) )
 	{
 		PlaySound( "wpn_hudon.wav", 1 );
 		p = GetFirstPos( iSlot );
-
-		if ( p && fastSwitch ) // check for fast weapon switch mode
-		{
-			// if fast weapon switch is on, then weapons can be selected in a single keypress
-			// but only if there is only one item in the bucket
-			WEAPON *p2 = GetNextActivePos( p->iSlot, p->iSlotPos );
-			if ( !p2 )
-			{	// only one active item in bucket, so change directly to weapon
-				ServerCmd( p->szName );
-				g_weaponselect = p->iId;
-				return;
-			}
-		}
 	}
 	else
 	{
@@ -483,11 +500,7 @@ void WeaponsResource :: SelectSlot( int iSlot, int fAdvance, int iDirection )
 	
 	if ( !p )  // no selection found
 	{
-		// just display the weapon list, unless fastswitch is on just ignore it
-		if ( !fastSwitch )
-			gpActiveSel = (WEAPON *)1;
-		else
-			gpActiveSel = NULL;
+		gpActiveSel = (WEAPON *)1;
 	}
 	else 
 		gpActiveSel = p;


### PR DESCRIPTION
![fast-switch](https://user-images.githubusercontent.com/729372/212471541-5e49d9e8-b88c-4a56-b267-b48c7cd60e75.gif)

cc: @N7P0L3ON