### PR TITLE
add-safe-precache

### DIFF
--- a/cl_dll/hl/hl_baseentity.cpp
+++ b/cl_dll/hl/hl_baseentity.cpp
@@ -30,6 +30,13 @@ This file contains "stubs" of class member implementations so that we can predic
 #include	"soundent.h"
 #include	"skill.h"
 
+// Safe Precache System Stubs. The original did not used hl_baseemtity
+// if you have custom model and sprites precahe you might have to add more...
+void SET_MODEL(struct edict_s *,char const *){ }
+int PRECACHE_MODEL(char *) {return 0; }
+int PRECACHE_SOUND(char *) { return 0; }
+unsigned short PRECACHE_EVENT(int,char const *){return 0; }
+
 // Globals used by game logic
 const Vector g_vecZero = Vector( 0, 0, 0 );
 int gmsgWeapPickup = 0;

--- a/dlls/animation.cpp
+++ b/dlls/animation.cpp
@@ -182,6 +182,7 @@ int IsSoundEvent( int eventNumber )
 	return 0;
 }
 
+extern int PRECACHE_SOUND(char *s); 
 
 void SequencePrecache( void *pmodel, const char *pSequenceName )
 {

--- a/dlls/enginecallback.h
+++ b/dlls/enginecallback.h
@@ -22,11 +22,13 @@
 extern enginefuncs_t g_engfuncs;
 
 // The actual engine callbacks
+// g-cont. see override functions in util.cpp
+//#define SET_MODEL		(*g_engfuncs.pfnSetModel)
+//#define PRECACHE_MODEL	(*g_engfuncs.pfnPrecacheModel)
+//#define PRECACHE_SOUND	(*g_engfuncs.pfnPrecacheSound)
+//#define PRECACHE_EVENT			(*g_engfuncs.pfnPrecacheEvent)
 #define GETPLAYERUSERID (*g_engfuncs.pfnGetPlayerUserId)
-#define PRECACHE_MODEL	(*g_engfuncs.pfnPrecacheModel)
-#define PRECACHE_SOUND	(*g_engfuncs.pfnPrecacheSound)
 #define PRECACHE_GENERIC	(*g_engfuncs.pfnPrecacheGeneric)
-#define SET_MODEL		(*g_engfuncs.pfnSetModel)
 #define MODEL_INDEX		(*g_engfuncs.pfnModelIndex)
 #define MODEL_FRAMES	(*g_engfuncs.pfnModelFrames)
 #define SET_SIZE		(*g_engfuncs.pfnSetSize)
@@ -126,7 +128,6 @@ inline void *GET_PRIVATE( edict_t *pent )
 #define NUMBER_OF_ENTITIES		(*g_engfuncs.pfnNumberOfEntities)
 #define IS_DEDICATED_SERVER		(*g_engfuncs.pfnIsDedicatedServer)
 
-#define PRECACHE_EVENT			(*g_engfuncs.pfnPrecacheEvent)
 #define PLAYBACK_EVENT_FULL		(*g_engfuncs.pfnPlaybackEvent)
 
 #define ENGINE_SET_PVS			(*g_engfuncs.pfnSetFatPVS)

--- a/dlls/util.h
+++ b/dlls/util.h
@@ -24,6 +24,24 @@
 #ifndef ENGINECALLBACK_H
 #include "enginecallback.h"
 #endif
+
+#include <string.h>
+
+//	g-cont. safe precaching models & sounds
+int PRECACHE_MODEL( char* s );								//	classic model precache 
+int PRECACHE_MODEL( string_t s );							//	pev->model as argument
+int PRECACHE_MODEL( string_t s, char *e );					//	custom model precache
+
+int PRECACHE_SOUND( char* s );								//	classic sound precache
+int PRECACHE_SOUND( string_t s );							//	pev->noise as argument
+int PRECACHE_SOUND( string_t s, char *e );					//	custom sound precache
+
+void SET_MODEL( edict_t *e, string_t model );				//	pev->model as argument
+void SET_MODEL( edict_t *e, const char *model );			//	classic set model
+void SET_MODEL( edict_t *e, string_t s, char *c );			//	custom model set
+
+unsigned short PRECACHE_EVENT( int type, const char *psz );	//	normal event precache 
+
 inline void MESSAGE_BEGIN( int msg_dest, int msg_type, const float *pOrigin, entvars_t *ent );  // implementation later in this file
 
 extern globalvars_t				*gpGlobals;

--- a/dlls/weapons.cpp
+++ b/dlls/weapons.cpp
@@ -64,6 +64,15 @@ DLL_GLOBAL	short	g_sModelIndexFlame;
 DLL_GLOBAL	short	g_Gibs;
 DLL_GLOBAL	short	g_Steamball;
 
+//	safe precaching system by g-cont 
+//	WARNING!!! this is critical stuff! do not edit this
+DLL_GLOBAL	short			g_sModelIndexNullModel; 	//	null model index
+DLL_GLOBAL	short			g_sModelIndexErrorModel;	//	error model index
+DLL_GLOBAL	short			g_sModelIndexNullSprite;	//	null sprite index
+DLL_GLOBAL	short			g_sModelIndexErrorSprite;	//	error sprite index
+DLL_GLOBAL	short			g_sSoundIndexNullSound;		//	null sound index
+DLL_GLOBAL	unsigned short	g_usEventIndexNullEvent;	//	null event index
+
 ItemInfo CBasePlayerItem::ItemInfoArray[MAX_WEAPONS];
 AmmoInfo CBasePlayerItem::AmmoInfoArray[MAX_AMMO_SLOTS];
 
@@ -358,6 +367,14 @@ void W_Precache(void)
 	memset( CBasePlayerItem::ItemInfoArray, 0, sizeof(CBasePlayerItem::ItemInfoArray) );
 	memset( CBasePlayerItem::AmmoInfoArray, 0, sizeof(CBasePlayerItem::AmmoInfoArray) );
 	giAmmoIndex = 0;
+
+	//	safe precaching system by g-cont 
+	//	WARNING!!! this is critical stuff! do not edit this
+	g_sSoundIndexNullSound 		=	g_engfuncs.pfnPrecacheSound	( "common/null.wav" );		//	Null sound file 
+	g_sModelIndexNullModel 		=	g_engfuncs.pfnPrecacheModel	( "models/null.mdl" );		//	Null model file 
+	g_sModelIndexErrorModel 	=	g_engfuncs.pfnPrecacheModel	( "models/error.mdl" );		//	Error model file 
+	g_sModelIndexNullSprite 	=	g_engfuncs.pfnPrecacheModel	( "sprites/null.spr" );		//	Null sprite file 
+	g_sModelIndexErrorSprite 	=	g_engfuncs.pfnPrecacheModel	( "sprites/error.spr" );	//	Error sprite file 
 
 	// custom items...
 

--- a/dlls/weapons.h
+++ b/dlls/weapons.h
@@ -515,6 +515,15 @@ extern DLL_GLOBAL	short	g_sModelConcreteGibs;
 extern DLL_GLOBAL	short	g_sModelLightning;
 extern DLL_GLOBAL	short	g_sModelIndexFlame;
 
+// 	safe precaching system by g-cont 
+//	WARNING!!! this is critical stuff! do not edit this
+extern DLL_GLOBAL	short			g_sModelIndexNullModel;		//	null model index
+extern DLL_GLOBAL	short			g_sModelIndexErrorModel;	//	error model index
+extern DLL_GLOBAL	short			g_sModelIndexNullSprite;	//	null sprite index
+extern DLL_GLOBAL	short			g_sModelIndexErrorSprite;	//	error sprite index
+extern DLL_GLOBAL	short			g_sSoundIndexNullSound;		//	null sound index
+extern DLL_GLOBAL	unsigned short	g_usEventIndexNullEvent;	//	null event index
+
 extern void ClearMultiDamage(void);
 extern void ApplyMultiDamage(entvars_t* pevInflictor, entvars_t* pevAttacker );
 extern void AddMultiDamage( entvars_t *pevInflictor, CBaseEntity *pEntity, float flDamage, int bitsDamageType);


### PR DESCRIPTION
- added Safe Precache system, the game will no longer crash on missing .mdl, .spr and .sc files
- system based on code from g-cont and XashXT Group