### PR TITLE
Fix repeating deploy sounds

### DIFF
--- a/cl_dll/entity.cpp
+++ b/cl_dll/entity.cpp
@@ -372,6 +372,9 @@ The entity's studio model description indicated an event was
 fired during this frame, handle the event by it's tag ( e.g., muzzleflash, sound )
 =========================
 */
+extern float g_DeploySoundTime;
+extern ref_params_t g_ViewParams;
+
 void CL_DLLEXPORT HUD_StudioEvent( const struct mstudioevent_s *event, const struct cl_entity_s *entity )
 {
 //	RecClStudioEvent(event, entity);
@@ -384,6 +387,11 @@ void CL_DLLEXPORT HUD_StudioEvent( const struct mstudioevent_s *event, const str
 		iMuzzleFlash = 0;
 
 #endif 
+
+	if (g_ViewParams.paused)
+	{
+		return;
+	}
 
 	switch( event->event )
 	{
@@ -423,14 +431,20 @@ void CL_DLLEXPORT HUD_StudioEvent( const struct mstudioevent_s *event, const str
 		gEngfuncs.pEfxAPI->R_SparkEffect( (float *)&entity->attachment[0], atoi( event->options), -100, 100 );
 		break;
 	// Client side sound
-	case 5004:		
+	case 5004:
 		gEngfuncs.pfnPlaySoundByNameAtLocation( (char *)event->options, 1.0, (float *)&entity->attachment[0] );
 		break;
 	case 5005:
 		if (cl_announcehumor && !cl_announcehumor->value) {
 			return;
 		}
+		if ( g_DeploySoundTime && g_DeploySoundTime > gEngfuncs.GetClientTime() )
+			return;
+#ifdef _DEBUG
+		gEngfuncs.Con_Printf(" >>>> [%7.2f] HUD_StudioEvent(5005, %s)!\n", gEngfuncs.GetClientTime(), (char *)event->options);
+#endif
 		gEngfuncs.pfnPlaySoundByNameAtLocation( (char *)event->options, 1.0, (float *)&entity->attachment[0] );
+		g_DeploySoundTime = gEngfuncs.GetClientTime() + 1.0;
 		break;
 	default:
 		break;

--- a/cl_dll/hud_msg.cpp
+++ b/cl_dll/hud_msg.cpp
@@ -43,6 +43,7 @@ void ClearEventList( void );
 float g_SlideTime = 0;
 float g_WallClimb = 0;
 float g_AcrobatTime = 0;
+float g_DeploySoundTime = 0;
 extern cvar_t *cl_antivomit;
 extern cvar_t *cl_icemodels;
 
@@ -108,6 +109,7 @@ void CHud :: MsgFunc_InitHUD( const char *pszName, int iSize, void *pbuf )
 	g_WallClimb = 0;
 	g_SlideTime = 0;
 	g_AcrobatTime = 0;
+	g_DeploySoundTime = 0;
 }
 
 
@@ -204,6 +206,10 @@ int CHud :: MsgFunc_PlayCSound( const char *pszName, int iSize, void *pbuf )
 {
 	BEGIN_READ( pbuf, iSize );
 	int index = READ_BYTE();
+
+	// Mute any incoming deploy sounds
+	g_DeploySoundTime = gEngfuncs.GetClientTime() + 1.0;
+
 	switch (index)
 	{
 		case CLIENT_SOUND_PREPAREFORBATTLE:

--- a/cl_dll/view.cpp
+++ b/cl_dll/view.cpp
@@ -62,6 +62,7 @@ extern engine_studio_api_t IEngineStudio;
 extern kbutton_t	in_mlook;
 
 float g_xP, g_yP;
+ref_params_t g_ViewParams;
 
 /*
 The view is allowed to move slightly from it's true position for bobbing,
@@ -1884,6 +1885,8 @@ void CL_DLLEXPORT V_CalcRefdef( struct ref_params_s *pparams )
 #endif
 		V_CalcNormalRefdef ( pparams );
 	}
+
+	g_ViewParams = *pparams;
 
 /*
 // Example of how to overlay the whole screen with red at 50 % alpha


### PR DESCRIPTION
Deploy sounds may repeat when the game is paused or connected to a server. Add a cool-down timer to reduce the chance of a repeat. The issue is generated outside of the client.dll.