### PR TITLE
Test night 2 fixes

### DIFF
--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -920,6 +920,14 @@ int CHudAmmo::Draw(float flTime)
 
 	ScaleColors(r, g, b, a );
 
+	if (gHUD.szActiveMutators != NULL &&
+		(strstr(gHUD.szActiveMutators, "dontshoot") ||
+		atoi(gHUD.szActiveMutators) == MUTATOR_DONTSHOOT))
+	{
+		SPR_Set(gHUD.GetSprite(gHUD.GetSpriteIndex("dontshoot")), r, g, b);
+		SPR_DrawAdditive(0, (ScreenWidth / 2) - 32, (ScreenHeight / 2) - 32, &gHUD.GetSpriteRect(gHUD.GetSpriteIndex("dontshoot")));
+	}
+
 	float up = cl_hudbend->value ? 1.5 : 1;
 	float left = cl_hudbend->value ? 15 : 0;
 

--- a/cl_dll/entity.cpp
+++ b/cl_dll/entity.cpp
@@ -549,7 +549,7 @@ void CL_DLLEXPORT HUD_TempEntUpdate (
 
 	currentEflag = player->curstate.eflags;
 
-	if (player && !cam_thirdperson)
+	if (player && !cam_thirdperson && !g_iUser1)
 	{
 		if (gHUD.m_flExtraViewModelTime == 0 /*|| currentEflag != lastEflag*/)
 		{

--- a/cl_dll/entity.cpp
+++ b/cl_dll/entity.cpp
@@ -591,12 +591,12 @@ void CL_DLLEXPORT HUD_TempEntUpdate (
 
 	// hold it
 	if (player && (player->curstate.eflags & EFLAG_DEADHANDS))
-		gHUD.m_flExtraViewModelTime = gEngfuncs.GetClientTime() + 0.01;
+		gHUD.m_flExtraViewModelTime = gEngfuncs.GetClientTime() + 0.1;
 
 	//static bool extra = false;
 	if (player && (player->curstate.eflags & EFLAG_SLIDE))
 	{
-		gHUD.m_flExtraViewModelTime = gEngfuncs.GetClientTime() + 0.01;
+		gHUD.m_flExtraViewModelTime = gEngfuncs.GetClientTime() + 0.1;
 		//extra = true;
 	}
 

--- a/cl_dll/hud_redraw.cpp
+++ b/cl_dll/hud_redraw.cpp
@@ -167,6 +167,12 @@ int CHud :: Redraw( float flTime, int intermission )
 	if (cl_portalmirror->value)
 		glDepthRange(0.0f, 0.0f);
 #endif
+
+	int r, g, b;
+	UnpackRGB(r, g, b, HudColor());
+	iTeamColors[0][0] = r;
+	iTeamColors[0][1] = g;
+	iTeamColors[0][2] = b;
 	
 	// draw all registered HUD elements
 	if ( m_pCvarDraw->value )

--- a/cl_dll/protip.cpp
+++ b/cl_dll/protip.cpp
@@ -30,6 +30,12 @@ void CHudProTip::AddMessage(int id, const char *message)
 	if (m_ShownTip[id])
 		return;
 
+	if (g_iUser1)
+		return;
+
+	if (gHUD.m_iIntermission)
+		return;
+
 	m_ShownTip[id] = true;
 
 	float time = gEngfuncs.GetClientTime() + SECONDS_TO_LIVE;
@@ -74,7 +80,9 @@ int CHudProTip::Draw(float flTime)
 	{
 		//gEngfuncs.Con_DPrintf("q index=%d, time=%.2f, ctime=%.2f\n", i, m_MessageQueue[i].time, gEngfuncs.GetClientTime());
 
-		if (m_MessageQueue[i].time > 0 && m_MessageQueue[i].time > gEngfuncs.GetClientTime())
+		if (m_MessageQueue[i].time > 0 &&
+			m_MessageQueue[i].time > gEngfuncs.GetClientTime() &&
+			m_MessageQueue[i].time <= (gEngfuncs.GetClientTime() + SECONDS_TO_LIVE + 3)) // in case of large values
 		{
 			int y = m_MessageQueue[i].y_pos;
 			y += 10;

--- a/cl_dll/protip.cpp
+++ b/cl_dll/protip.cpp
@@ -70,7 +70,7 @@ int CHudProTip::Draw(float flTime)
 	if (g_iUser1)
 		return 1;
 
-	if (gHUD.m_Scoreboard.m_iShowscoresHeld)
+	if (gHUD.m_Scoreboard.m_iShowscoresHeld || gHUD.m_iShowingWeaponMenu)
 		return 1;
 
 	if (gHUD.m_iIntermission)

--- a/cl_dll/status_icons.cpp
+++ b/cl_dll/status_icons.cpp
@@ -61,7 +61,7 @@ int CHudStatusIcons::Draw( float flTime )
 		return 1;
 
 	// find starting position to draw from, along right-hand side of screen
-	int x = 24 + g_xP;
+	int x = 32 + g_xP;
 	int y = (ScreenHeight / 1.5) + g_yP;
 	
 	// loop through icon list, and draw any valid icons drawing up from the middle of screen

--- a/cl_dll/vgui_MOTDWindow.cpp
+++ b/cl_dll/vgui_MOTDWindow.cpp
@@ -92,11 +92,8 @@ CMessageWindowPanel::CMessageWindowPanel( const char *szMOTD, const char *szTitl
 	Label *pLabel = new Label( "", iXPos + MOTD_TITLE_X, iYPos + MOTD_TITLE_Y );
 	pLabel->setParent( this );
 	pLabel->setFont( pSchemes->getFont(hTitleScheme) );
-	pLabel->setFont( Scheme::sf_primary1 );
-
 	pSchemes->getFgColor( hTitleScheme, r, g, b, a );
 	pLabel->setFgColor( r, g, b, a );
-	pLabel->setFgColor( Scheme::sc_primary1 );
 	pSchemes->getBgColor( hTitleScheme, r, g, b, a );
 	pLabel->setBgColor( r, g, b, a );
 	pLabel->setContentAlignment( vgui::Label::a_west );

--- a/cl_dll/vgui_ScorePanel.cpp
+++ b/cl_dll/vgui_ScorePanel.cpp
@@ -110,7 +110,9 @@ ScorePanel::ScorePanel(int x,int y,int wide,int tall) : Panel(x,y,wide,tall)
 	m_TitleLabel.setFont(tfont);
 	m_TitleLabel.setText("");
 	m_TitleLabel.setBgColor( 0, 0, 0, 255 );
-	m_TitleLabel.setFgColor( Scheme::sc_primary1 );
+	int r, g, b;
+	UnpackRGB(r, g, b, HudColor());
+	m_TitleLabel.setFgColor( r, g, b, 0 );
 	m_TitleLabel.setContentAlignment( vgui::Label::a_west );
 
 	LineBorder *border = new LineBorder(Color(60, 60, 60, 128));
@@ -162,7 +164,7 @@ ScorePanel::ScorePanel(int x,int y,int wide,int tall) : Panel(x,y,wide,tall)
 		m_HeaderGrid.SetEntry(i, 0, &m_HeaderLabels[i]);
 
 		m_HeaderLabels[i].setBgColor(0,0,0,255);
-		m_HeaderLabels[i].setFgColor(Scheme::sc_primary1);
+		m_HeaderLabels[i].setFgColor(r, g, b, 255);
 		m_HeaderLabels[i].setFont(smallfont);
 		m_HeaderLabels[i].setContentAlignment(g_ColumnInfo[i].m_Alignment);
 
@@ -268,6 +270,9 @@ void ScorePanel::Update()
 	{
 		char sz[MAX_SERVERNAME_LENGTH + 16];
 		sprintf(sz, "%s", gViewPort->m_szServerName );
+		int r, g, b;
+		UnpackRGB(r, g, b, HudColor());
+		m_TitleLabel.setFgColor( r, g, b, 0 );
 		m_TitleLabel.setText(sz);
 	}
 

--- a/cl_dll/vgui_SpectatorPanel.cpp
+++ b/cl_dll/vgui_SpectatorPanel.cpp
@@ -102,8 +102,10 @@ void SpectatorPanel::Initialize()
 	m_TopBorder->setParent(this);
 	Panel *pp = new Panel( 0, PANEL_HEIGHT, ScreenWidth, 1);
 	pp->setParent( this );
-	pp->setFgColor( 0, 113, 230, 0 );
-	pp->setBgColor( 0, 113, 230, 0 );
+	int r, g, b;
+	UnpackRGB(r, g, b, HudColor());
+	pp->setFgColor( r, g, b, 0 );
+	pp->setBgColor( r, g, b, 0 );
 
 	Label *dead = new Label( "", 10, 10, wide, PANEL_HEIGHT - 10 );
 	dead->setParent(m_TopBorder);
@@ -237,7 +239,7 @@ void SpectatorPanel::Initialize()
 	m_BottomMainButton->setArmedBorderColor ( 194, 202, 54, 0 );
 	m_BottomMainButton->setUnArmedColor ( 143, 143, 54, 0 );
 	m_BottomMainButton->setArmedColor ( 194, 202, 54, 0 );
-	m_BottomMainButton->setFgColor( 0, 113, 230, 0 );
+	m_BottomMainButton->setFgColor( r, g, b, 0 );
 
 	m_BottomMainLabel = new Label("", 0, 0, wide, PANEL_HEIGHT);
 
@@ -245,7 +247,7 @@ void SpectatorPanel::Initialize()
 	m_BottomMainLabel->setPaintBackgroundEnabled(false);
 	//m_BottomMainLabel->setFgColor( Scheme::sc_primary1 );
 	m_BottomMainLabel->setFont( pSchemes->getFont(hLargeScheme) );
-	m_BottomMainLabel->setFgColor(0, 113, 230, 0);
+	m_BottomMainLabel->setFgColor(r, g, b, 0);
 	m_BottomMainLabel->setContentAlignment( vgui::Label::a_center );
 	m_BottomMainLabel->setBorder( NULL );
 	m_BottomMainLabel->setVisible(false);
@@ -254,11 +256,11 @@ void SpectatorPanel::Initialize()
 	m_InsetViewButton->setParent( this );
 	m_InsetViewButton->setBoundKey( (char)255 );
 	m_InsetViewButton->addActionSignal( new CSpectatorHandler_Command(this,SPECTATOR_PANEL_CMD_TOGGLE_INSET) );
-	m_InsetViewButton->setUnArmedBorderColor ( 0, 113, 230, 0 );
+	m_InsetViewButton->setUnArmedBorderColor ( r, g, b, 0 );
 	m_InsetViewButton->setArmedBorderColor ( 255, 255, 255, 0 );
-	m_InsetViewButton->setUnArmedColor ( 0, 113, 230, 0 );
+	m_InsetViewButton->setUnArmedColor ( r, g, b, 0 );
 	m_InsetViewButton->setArmedColor ( 255, 255, 255, 0 );
-	m_InsetViewButton->setBgColor( 0, 113, 230, 200 );
+	m_InsetViewButton->setBgColor( r, g, b, 200 );
 	//m_InsetViewButton->setArmed(TRUE);
 
 	m_menuVisible = false;

--- a/cl_dll/vgui_TeamFortressViewport.cpp
+++ b/cl_dll/vgui_TeamFortressViewport.cpp
@@ -239,6 +239,10 @@ char *sMutators[] = {
 	"slowweapons",
 	"fastweapons",
 	"jack",
+	"piratehat",
+	"marshmellow",
+	"crate",
+	"pumpkin",
 	"RANDOM",
 };
 

--- a/cl_dll/vgui_TeamFortressViewport.cpp
+++ b/cl_dll/vgui_TeamFortressViewport.cpp
@@ -1743,8 +1743,10 @@ void TeamFortressViewport::UpdateSpectatorPanel()
 		}
 		else
 		{	// restore GUI color
-			m_pSpectatorPanel->m_BottomMainLabel->setFgColor( 0, 160, 255, 0 );
-			m_pSpectatorPanel->m_BottomMainButton->setFgColor( 0, 160, 255, 0 );
+			int r, g, b;
+			UnpackRGB(r, g, b, HudColor());
+			m_pSpectatorPanel->m_BottomMainLabel->setFgColor( r, g, b, 0 );
+			m_pSpectatorPanel->m_BottomMainButton->setFgColor( r, g, b, 0 );
 		}
 
 		// add sting auto if we are in auto directed mode

--- a/cl_dll/vgui_TeamFortressViewport.h
+++ b/cl_dll/vgui_TeamFortressViewport.h
@@ -1737,7 +1737,7 @@ public:
 
 #define MAX_MODES	9 // CHILLDEMIC + RANDOM
 #define MAX_MAPS	32 // cold_base (30) + RANDOM
-#define MAX_MUTATORS	48 // fastweapons (46) + RANDOM
+#define MAX_MUTATORS	52 // pumpkin (50 + 1) + RANDOM
 
 class CVoteGameplayPanel : public CMenuPanel
 {

--- a/cl_dll/vgui_VoteMutatorWindow.cpp
+++ b/cl_dll/vgui_VoteMutatorWindow.cpp
@@ -51,11 +51,21 @@ CVoteMutatorPanel::CVoteMutatorPanel(int iTrans, int iRemoveMe, int x,int y,int 
 	pTitleLabel->setText(gHUD.m_TextMessage.BufferedLocaliseTextString("#Title_VoteMutator"));
 
 	// Create the buttons
+	int positionCount = 0;
 	for (int i = 0; i < MAX_MUTATORS; i++)
 	{
+		m_pButtons[i] = NULL;
+		if (strstr(sMutators[i], "slowmo") ||
+			strstr(sMutators[i], "speedup") ||
+			strstr(sMutators[i], "topsyturvy") ||
+			strstr(sMutators[i], "explosiveai"))
+		{
+			continue;
+		}
+
 		// Space for random button
-		int xI = i+1;
-		int degree = (i+1) / 12;
+		int xI = positionCount+1;
+		int degree = (positionCount+1) / 12;
 		if (i == MAX_MUTATORS - 1)
 		{
 			xI = 0;
@@ -79,6 +89,7 @@ CVoteMutatorPanel::CVoteMutatorPanel(int iTrans, int iRemoveMe, int x,int y,int 
 		m_pButtons[i]->addActionSignal( pASignal );
 		m_pButtons[i]->addInputSignal( new CHandler_MenuButtonOver(this, i) );
 		m_pButtons[i]->setParent(this);
+		positionCount++;
 	}
 
 	m_iCurrentInfo = 0;
@@ -95,7 +106,10 @@ void CVoteMutatorPanel::Update()
 
 	// Count votes
 	for (int j = 0; j < MAX_MUTATORS; j++)
-		m_pButtons[j]->setArmed(false);
+	{
+		if (m_pButtons[j])
+			m_pButtons[j]->setArmed(false);
+	}
 
 	// Count votes
 	for ( int i = 0; i < MAX_MUTATORS; i++ )
@@ -110,12 +124,18 @@ void CVoteMutatorPanel::Update()
 				votes[i] += 1;
 		}
 
-		char sz[64];
-		sprintf(sz, " %-2d %s", votes[i], sMutators[i]);
-		m_pButtons[i]->setText(sz);
+		if (m_pButtons[i])
+		{
+			char sz[64];
+			sprintf(sz, " %-2d %s", votes[i], sMutators[i]);
+			m_pButtons[i]->setText(sz);
+		}
 
 		if ((myVote - 1) == i)
-			m_pButtons[i]->setArmed(true);
+		{
+			if (m_pButtons[i])
+				m_pButtons[i]->setArmed(true);
+		}
 	}
 
 	pTitleLabel->setText("%s | Your Vote: %s | Time Left: %.1f\n",
@@ -137,7 +157,8 @@ bool CVoteMutatorPanel::SlotInput( int iSlot )
 	{
 		for (int i = 0; i < MAX_MUTATORS; i++)
 		{
-			m_pButtons[i]->setArmed( false );
+			if (m_pButtons[i])
+				m_pButtons[i]->setArmed( false );
 		}
 
 		m_pButtons[ iSlot ]->setArmed( true );

--- a/cl_dll/voice_status.cpp
+++ b/cl_dll/voice_status.cpp
@@ -619,7 +619,9 @@ void CVoiceStatus::UpdateBanButton(int iClient)
 		{
 			pPanel->setImage(m_pScoreboardSpeaking);
 		}
-		pPanel->setFgColor(0, 113, 230, 1);
+		int r, g, b;
+		UnpackRGB(r, g, b, HudColor());
+		pPanel->setFgColor(r, g, b, 1);
 	}
 	else if (bNeverSpoken)
 	{

--- a/dlls/chilldemic_gamerules.cpp
+++ b/dlls/chilldemic_gamerules.cpp
@@ -707,3 +707,11 @@ int CHalfLifeChilldemic::GetTeamIndex( const char *pTeamName )
 	
 	return -1;	// No match
 }
+
+BOOL CHalfLifeChilldemic::CanRandomizeWeapon( const char *name )
+{
+	if (strcmp(name, "weapon_nuke") == 0)
+		return FALSE;
+
+	return TRUE;
+}

--- a/dlls/chilldemic_gamerules.cpp
+++ b/dlls/chilldemic_gamerules.cpp
@@ -581,7 +581,6 @@ void CHalfLifeChilldemic::PlayerSpawn( CBasePlayer *pPlayer )
 		pPlayer->GiveNamedItem("weapon_vest");
 		pPlayer->GiveNamedItem("weapon_chainsaw");
 		pPlayer->pev->max_health = pPlayer->pev->health = 50;
-		pPlayer->pev->maxspeed = CVAR_GET_FLOAT("sv_maxspeed");
 		g_engfuncs.pfnSetPhysicsKeyValue(pPlayer->edict(), "haste", "1");
 
 		strncpy( pPlayer->m_szTeamName, "skeleton", TEAM_NAME_LENGTH );
@@ -597,7 +596,6 @@ void CHalfLifeChilldemic::PlayerSpawn( CBasePlayer *pPlayer )
 		else
 			strcpy(modelName, defaultPlayerModels[RANDOM_LONG(0,3)]);
 		pPlayer->GiveRandomWeapon("weapon_nuke");
-		pPlayer->pev->maxspeed = CVAR_GET_FLOAT("sv_maxspeed") * .5;
 
 		strncpy( pPlayer->m_szTeamName, "survivors", TEAM_NAME_LENGTH );
 		g_engfuncs.pfnSetClientKeyValue(ENTINDEX(pPlayer->edict()), key, "model", modelName);

--- a/dlls/chilldemic_gamerules.h
+++ b/dlls/chilldemic_gamerules.h
@@ -27,6 +27,7 @@ public:
 	virtual void PlayerKilled( CBasePlayer *pVictim, entvars_t *pKiller, entvars_t *pInflictor );
 	virtual BOOL CanHavePlayerItem( CBasePlayer *pPlayer, CBasePlayerItem *pWeapon );
 	virtual int GetTeamIndex( const char *pTeamName );
+	virtual BOOL CanRandomizeWeapon( const char *name );
 
 private:
 	int m_iSurvivorsRemain;

--- a/dlls/chumtoad.cpp
+++ b/dlls/chumtoad.cpp
@@ -101,10 +101,10 @@ void CCaptureChumtoad::Spawn( void )
 	Precache( );
 	// motor
 	pev->movetype = MOVETYPE_BOUNCE;
-	pev->solid = SOLID_BBOX;
+	pev->solid = SOLID_TRIGGER;
 
 	SET_MODEL(ENT(pev), "models/w_chumtoad.mdl");
-	UTIL_SetSize(pev, Vector( -4, -4, 0), Vector(4, 4, 8));
+	UTIL_SetSize(pev, Vector(-16, -16, 0), Vector(16, 16, 8));
 	UTIL_SetOrigin( pev, pev->origin );
 
 	SetTouch( &CCaptureChumtoad::SuperBounceTouch );

--- a/dlls/combat.cpp
+++ b/dlls/combat.cpp
@@ -1188,7 +1188,7 @@ void RadiusDamage( Vector vecSrc, entvars_t *pevInflictor, entvars_t *pevAttacke
 					flAdjustedDamage = 0;
 				}
 
-				flAdjustedDamage += ::IceExplode(pEntity, bitsDamageType);
+				flAdjustedDamage += ::IceExplode(GetClassPtr((CBaseEntity *)pevAttacker), pEntity, bitsDamageType);
 
 				// ALERT( at_console, "hit %s\n", STRING( pEntity->pev->classname ) );
 				if (tr.flFraction != 1.0)

--- a/dlls/ctc_gamerules.cpp
+++ b/dlls/ctc_gamerules.cpp
@@ -43,6 +43,19 @@ void CHalfLifeCaptureTheChumtoad::Think( void )
 {
 	CHalfLifeMultiplay::Think();
 
+	// No loop during intermission
+	if ( m_flIntermissionEndTime )
+	{
+		// Remove any left
+		edict_t *pEdict = FIND_ENTITY_BY_CLASSNAME(NULL, "monster_ctctoad");
+		while (!FNullEnt(pEdict))
+		{
+			UTIL_Remove(CBaseEntity::Instance(pEdict));
+			pEdict = FIND_ENTITY_BY_CLASSNAME(pEdict, "monster_ctctoad");
+		}
+		return;
+	}
+
 	if (m_fChumtoadPlayTimer < gpGlobals->time)
 	{
 		edict_t *pEdict = FIND_ENTITY_BY_CLASSNAME(NULL, "monster_ctctoad");

--- a/dlls/dual_wrench.cpp
+++ b/dlls/dual_wrench.cpp
@@ -301,7 +301,7 @@ int CDualWrench::Swing( int fFirst )
 		if (pEntity->pev->deadflag != DEAD_FAKING && FBitSet(pEntity->pev->flags, FL_FROZEN)) {
 			pEntity->pev->renderamt = 100;
 			flDamage = 200;
-			::IceExplode(pEntity, DMG_FREEZE);
+			::IceExplode(m_pPlayer, pEntity, DMG_FREEZE);
 		}
 
 		if ( (m_flNextPrimaryAttack + 1 < UTIL_WeaponTimeBase() ) || g_pGameRules->IsMultiplayer() )

--- a/dlls/fists.cpp
+++ b/dlls/fists.cpp
@@ -215,7 +215,7 @@ int CFists::Swing( int fFirst )
 		if (pEntity->pev->deadflag != DEAD_FAKING && fFirst == SHORYUKEN && FBitSet(pEntity->pev->flags, FL_FROZEN)) {
 			pEntity->pev->renderamt = 100;
 			flDamage = 200;
-			::IceExplode(pEntity, DMG_FREEZE);
+			::IceExplode(m_pPlayer, pEntity, DMG_FREEZE);
 		}
 
 		if ( (m_flNextPrimaryAttack + 1 < UTIL_WeaponTimeBase() ) || g_pGameRules->IsMultiplayer() )

--- a/dlls/gamerules.cpp
+++ b/dlls/gamerules.cpp
@@ -625,7 +625,6 @@ void CGameRules::SpawnMutators(CBasePlayer *pPlayer)
 	if (strstr(mutators.string, g_Mutator999) ||
 		atoi(mutators.string) == MUTATOR_999) {
 		pPlayer->pev->max_health = 999;
-		pPlayer->pev->armortype = 999;
 		pPlayer->pev->health = 999;
 		pPlayer->pev->armorvalue = 999;
 	}

--- a/dlls/gamerules.cpp
+++ b/dlls/gamerules.cpp
@@ -628,13 +628,6 @@ void CGameRules::SpawnMutators(CBasePlayer *pPlayer)
 		pPlayer->pev->health = 999;
 		pPlayer->pev->armorvalue = 999;
 	}
-
-	if (strstr(mutators.string, g_MutatorJeepAThon) ||
-		atoi(mutators.string) == MUTATOR_JEEPATHON) {
-		if (!pPlayer->IsObserver())
-			pPlayer->m_EFlags &= ~EFLAG_CANCEL;
-			pPlayer->m_EFlags |= EFLAG_JEEP;
-	}
 }
 
 void CGameRules::GiveMutators(CBasePlayer *pPlayer)

--- a/dlls/gamerules.cpp
+++ b/dlls/gamerules.cpp
@@ -807,12 +807,17 @@ void CGameRules::CheckMutators(void)
 			strcpy(szSkyColor[2], CVAR_GET_STRING("sv_skycolor_b"));
 		}
 
+		int toggleFlashlight = 0;
+
 		if ((strstr(mutators.string, g_MutatorLightsOut) ||
 			atoi(mutators.string) == MUTATOR_LIGHTSOUT))
 		{
 			LIGHT_STYLE(0, "b");
 			if (flashlight.value != 1)
+			{
 				CVAR_SET_STRING("mp_flashlight", "2");
+				toggleFlashlight = 2;
+			}
 			CVAR_SET_STRING("sv_skycolor_r", "0");
 			CVAR_SET_STRING("sv_skycolor_g", "0");
 			CVAR_SET_STRING("sv_skycolor_b", "0");
@@ -821,7 +826,10 @@ void CGameRules::CheckMutators(void)
 		{
 			LIGHT_STYLE(0, "m");
 			if (flashlight.value == 2)
+			{
 				CVAR_SET_STRING("mp_flashlight", "0");
+				toggleFlashlight = 1;
+			}
 			CVAR_SET_STRING("sv_skycolor_r", szSkyColor[0]);
 			CVAR_SET_STRING("sv_skycolor_g", szSkyColor[1]);
 			CVAR_SET_STRING("sv_skycolor_b", szSkyColor[2]);
@@ -900,6 +908,14 @@ void CGameRules::CheckMutators(void)
 						if (pl->pev->rendermode == kRenderTransAlpha)
 							pl->pev->rendermode = kRenderNormal;
 					}
+				}
+
+				if (toggleFlashlight)
+				{
+					if ( toggleFlashlight == 2 && !pl->FlashlightIsOn() )
+						pl->FlashlightTurnOn();
+					else if (toggleFlashlight == 1 && pl->FlashlightIsOn())
+						pl->FlashlightTurnOff();
 				}
 
 				if (m_JopeCheck) {

--- a/dlls/gamerules.cpp
+++ b/dlls/gamerules.cpp
@@ -539,7 +539,7 @@ BOOL CGameRules::WeaponMutators( CBasePlayerWeapon *pWeapon )
 	{
 		if (m_iDontShoot)
 		{
-			if (pWeapon->iItemSlot() != 1 && pWeapon->m_pPlayer->pev->solid != SOLID_NOT)
+			if (pWeapon->pszAmmo1() != NULL && pWeapon->m_pPlayer->pev->solid != SOLID_NOT)
 			{
 				if (!FBitSet(pWeapon->m_pPlayer->pev->flags, FL_GODMODE))
 				{

--- a/dlls/gamerules.cpp
+++ b/dlls/gamerules.cpp
@@ -625,13 +625,24 @@ void CGameRules::SpawnMutators(CBasePlayer *pPlayer)
 	if (strstr(mutators.string, g_Mutator999) ||
 		atoi(mutators.string) == MUTATOR_999) {
 		pPlayer->pev->max_health = 999;
+		pPlayer->pev->armortype = 999;
 		pPlayer->pev->health = 999;
 		pPlayer->pev->armorvalue = 999;
+	}
+
+	if (strstr(mutators.string, g_MutatorJeepAThon) ||
+		atoi(mutators.string) == MUTATOR_JEEPATHON) {
+		if (!pPlayer->IsObserver())
+			pPlayer->m_EFlags &= ~EFLAG_CANCEL;
+			pPlayer->m_EFlags |= EFLAG_JEEP;
 	}
 }
 
 void CGameRules::GiveMutators(CBasePlayer *pPlayer)
 {
+	if (!pPlayer->IsAlive())
+		return;
+
 	if (strstr(mutators.string, g_MutatorRocketCrowbar) ||
 		atoi(mutators.string) == MUTATOR_ROCKETCROWBAR) {
 		if (!pPlayer->HasNamedPlayerItem("weapon_rocketcrowbar"))

--- a/dlls/gamerules.h
+++ b/dlls/gamerules.h
@@ -474,4 +474,5 @@ protected:
 };
 
 extern DLL_GLOBAL CGameRules*	g_pGameRules;
-extern const char *g_szMutators[51];
+#define MAX_MUTATORS 51
+extern const char *g_szMutators[MAX_MUTATORS];

--- a/dlls/gungame_gamerules.cpp
+++ b/dlls/gungame_gamerules.cpp
@@ -380,8 +380,8 @@ int CHalfLifeGunGame::IPointsForKill( CBasePlayer *pAttacker, CBasePlayer *pKill
 				if (pAttacker->IsAlive())
 				{
 					pAttacker->RemoveAllItems(FALSE);
-					GiveMutators(pAttacker);
 					pAttacker->GiveNamedItem("weapon_fists");
+					GiveMutators(pAttacker);
 					char weapon[32];
 					sprintf(weapon, "%s%s", "weapon_", g_WeaponId[newLevel]);
 					pAttacker->GiveNamedItem(weapon);

--- a/dlls/gungame_gamerules.cpp
+++ b/dlls/gungame_gamerules.cpp
@@ -466,3 +466,19 @@ BOOL CHalfLifeGunGame::IsAllowedToHolsterWeapon( void )
 {
 	return FALSE;
 }
+
+BOOL CHalfLifeGunGame::CanHavePlayerItem( CBasePlayer *pPlayer, CBasePlayerItem *pItem )
+{
+	if (!strcmp(STRING(pItem->pev->classname), "weapon_nuke"))
+		return FALSE;
+
+	return CHalfLifeMultiplay::CanHavePlayerItem( pPlayer, pItem );
+}
+
+BOOL CHalfLifeGunGame::CanRandomizeWeapon( const char *name )
+{
+	if (strcmp(name, "weapon_nuke") == 0)
+		return FALSE;
+
+	return TRUE;
+}

--- a/dlls/gungame_gamerules.cpp
+++ b/dlls/gungame_gamerules.cpp
@@ -380,11 +380,12 @@ int CHalfLifeGunGame::IPointsForKill( CBasePlayer *pAttacker, CBasePlayer *pKill
 				if (pAttacker->IsAlive())
 				{
 					pAttacker->RemoveAllItems(FALSE);
-					pAttacker->GiveNamedItem("weapon_fists");
 					GiveMutators(pAttacker);
+					if (!pAttacker->HasNamedPlayerItem("weapon_fists"))
+						pAttacker->GiveNamedItem("weapon_fists");
 					char weapon[32];
 					sprintf(weapon, "%s%s", "weapon_", g_WeaponId[newLevel]);
-					pAttacker->GiveNamedItem(weapon);
+					pAttacker->GiveNamedItem(STRING(ALLOC_STRING(weapon)));
 				}
 				m_hVoiceHandle = pAttacker;
 				m_fRefreshStats = gpGlobals->time + 1.0;
@@ -415,7 +416,7 @@ void CHalfLifeGunGame::PlayerSpawn( CBasePlayer *pPlayer )
 	int currentLevel = (int)pPlayer->pev->fuser4;
 	char weapon[32];
 	sprintf(weapon, "%s%s", "weapon_", g_WeaponId[currentLevel]);
-	pPlayer->GiveNamedItem(weapon);
+	pPlayer->GiveNamedItem(STRING(ALLOC_STRING(weapon)));
 	pPlayer->GiveAmmo(AMMO_GLOCKCLIP_GIVE * 4, "9mm", _9MM_MAX_CARRY);
 	pPlayer->GiveAmmo(AMMO_357BOX_GIVE * 4, "357", _357_MAX_CARRY);
 	pPlayer->GiveAmmo(AMMO_BUCKSHOTBOX_GIVE * 4, "buckshot", BUCKSHOT_MAX_CARRY);

--- a/dlls/gungame_gamerules.cpp
+++ b/dlls/gungame_gamerules.cpp
@@ -40,54 +40,54 @@ int g_iFrags[MAXLEVEL+1] = { 1, 3, 5, 6, 9, 12, 15, 18, 21, 26, 29, 30, 31, 32, 
 const char *g_WeaponId[MAXLEVEL+1] = 
 {
 	// hand
-	"weapon_9mmhandgun", //level 0
-	"weapon_deagle",
-	"weapon_dual_deagle",
-	"weapon_python",
-	"weapon_mag60",
-	"weapon_dual_mag60",
-	"weapon_smg",
-	"weapon_dual_smg",
-	"weapon_sawedoff",
-	"weapon_dual_sawedoff",
+	"9mmhandgun", //level 0
+	"deagle",
+	"dual_deagle",
+	"python",
+	"mag60",
+	"dual_mag60",
+	"smg",
+	"dual_smg",
+	"sawedoff",
+	"dual_sawedoff",
 	// long
-	"weapon_9mmAR",
-	"weapon_12gauge",
-	"weapon_shotgun",
-	"weapon_crossbow",
-	"weapon_sniperrifle",
-	"weapon_chaingun",
-	"weapon_usas",
-	"weapon_dual_usas",
-	"weapon_freezegun",
+	"9mmAR",
+	"12gauge",
+	"shotgun",
+	"crossbow",
+	"sniperrifle",
+	"chaingun",
+	"usas",
+	"dual_usas",
+	"freezegun",
 	// heavy
-	"weapon_rpg",
-	"weapon_dual_rpg",
-	"weapon_railgun",
-	"weapon_dual_railgun",
-	"weapon_cannon",
-	"weapon_gauss",
-	"weapon_egon",
-	"weapon_hornetgun",
-	"weapon_glauncher",
-	"weapon_flamethrower",
-	"weapon_dual_flamethrower",
-	"weapon_gravitygun",
+	"rpg",
+	"dual_rpg",
+	"railgun",
+	"dual_railgun",
+	"cannon",
+	"gauss",
+	"egon",
+	"hornetgun",
+	"glauncher",
+	"flamethrower",
+	"dual_flamethrower",
+	"gravitygun",
 	// loose
-	"weapon_snowball",
-	"weapon_handgrenade",
-	"weapon_satchel",
-	"weapon_tripmine",
-	"weapon_snark",
-	"weapon_chumtoad",
-	"weapon_vest",
+	"snowball",
+	"handgrenade",
+	"satchel",
+	"tripmine",
+	"snark",
+	"chumtoad",
+	"vest",
 	// hand
-	"weapon_chainsaw",
-	"weapon_dual_wrench",
-	"weapon_wrench",
-	"weapon_crowbar",
-	"weapon_fists",
-	"weapon_knife",
+	"chainsaw",
+	"dual_wrench",
+	"wrench",
+	"crowbar",
+	"fists",
+	"knife",
 	"Winner"
 };
 
@@ -382,7 +382,9 @@ int CHalfLifeGunGame::IPointsForKill( CBasePlayer *pAttacker, CBasePlayer *pKill
 					pAttacker->RemoveAllItems(FALSE);
 					GiveMutators(pAttacker);
 					pAttacker->GiveNamedItem("weapon_fists");
-					pAttacker->GiveNamedItem(g_WeaponId[newLevel]);
+					char weapon[32];
+					sprintf(weapon, "%s%s", "weapon_", g_WeaponId[newLevel]);
+					pAttacker->GiveNamedItem(weapon);
 				}
 				m_hVoiceHandle = pAttacker;
 				m_fRefreshStats = gpGlobals->time + 1.0;
@@ -402,35 +404,35 @@ int CHalfLifeGunGame::IPointsForKill( CBasePlayer *pAttacker, CBasePlayer *pKill
 void CHalfLifeGunGame::PlayerSpawn( CBasePlayer *pPlayer )
 {
 	pPlayer->pev->weapons |= (1<<WEAPON_SUIT);
+	pPlayer->GiveNamedItem("weapon_fists");
 
-	if (pPlayer)
-	{
-		// In full game, go deep with negative deaths but in short game, pin to lowest level
-		if (ggstartlevel.value > 0 && pPlayer->pev->fuser4 < ggstartlevel.value) {
-			pPlayer->pev->fuser4 = ggstartlevel.value;
-			pPlayer->pev->frags = g_iFrags[(int)ggstartlevel.value - 1];
-		}
-		
-		int currentLevel = (int)pPlayer->pev->fuser4;
-		pPlayer->GiveNamedItem(g_WeaponId[currentLevel]);
-		pPlayer->GiveAmmo(AMMO_GLOCKCLIP_GIVE * 4, "9mm", _9MM_MAX_CARRY);
-		pPlayer->GiveAmmo(AMMO_357BOX_GIVE * 4, "357", _357_MAX_CARRY);
-		pPlayer->GiveAmmo(AMMO_BUCKSHOTBOX_GIVE * 4, "buckshot", BUCKSHOT_MAX_CARRY);
-		pPlayer->GiveAmmo(AMMO_CROSSBOWCLIP_GIVE * 4, "bolts", BOLT_MAX_CARRY);
-		pPlayer->GiveAmmo(AMMO_M203BOX_GIVE * 2, "ARgrenades", M203_GRENADE_MAX_CARRY);
-		pPlayer->GiveAmmo(AMMO_RPGCLIP_GIVE * 2, "rockets", ROCKET_MAX_CARRY);
-		pPlayer->GiveAmmo(AMMO_URANIUMBOX_GIVE * 4, "uranium", URANIUM_MAX_CARRY);
-
-		ClientPrint(pPlayer->pev, HUD_PRINTTALK, UTIL_VarArgs("[GunGame]: You need %d frags to reach level %s.\n",
-			g_iFrags[currentLevel] - ((int)pPlayer->pev->frags), g_WeaponId[currentLevel+1]));
+	// In full game, go deep with negative deaths but in short game, pin to lowest level
+	if (ggstartlevel.value > 0 && pPlayer->pev->fuser4 < ggstartlevel.value) {
+		pPlayer->pev->fuser4 = ggstartlevel.value;
+		pPlayer->pev->frags = g_iFrags[(int)ggstartlevel.value - 1];
 	}
+	
+	int currentLevel = (int)pPlayer->pev->fuser4;
+	char weapon[32];
+	sprintf(weapon, "%s%s", "weapon_", g_WeaponId[currentLevel]);
+	pPlayer->GiveNamedItem(weapon);
+	pPlayer->GiveAmmo(AMMO_GLOCKCLIP_GIVE * 4, "9mm", _9MM_MAX_CARRY);
+	pPlayer->GiveAmmo(AMMO_357BOX_GIVE * 4, "357", _357_MAX_CARRY);
+	pPlayer->GiveAmmo(AMMO_BUCKSHOTBOX_GIVE * 4, "buckshot", BUCKSHOT_MAX_CARRY);
+	pPlayer->GiveAmmo(AMMO_CROSSBOWCLIP_GIVE * 4, "bolts", BOLT_MAX_CARRY);
+	pPlayer->GiveAmmo(AMMO_M203BOX_GIVE * 2, "ARgrenades", M203_GRENADE_MAX_CARRY);
+	pPlayer->GiveAmmo(AMMO_RPGCLIP_GIVE * 2, "rockets", ROCKET_MAX_CARRY);
+	pPlayer->GiveAmmo(AMMO_URANIUMBOX_GIVE * 4, "uranium", URANIUM_MAX_CARRY);
+
+	ClientPrint(pPlayer->pev, HUD_PRINTTALK, UTIL_VarArgs("[GunGame]: You need %d frags to reach level %s.\n",
+		g_iFrags[currentLevel] - ((int)pPlayer->pev->frags), g_WeaponId[currentLevel+1]));
 
 	g_pGameRules->SpawnMutators(pPlayer);
 }
 
 BOOL CHalfLifeGunGame::IsAllowedToSpawn( CBaseEntity *pEntity )
 {
-	if (strncmp(STRING(pEntity->pev->classname), "weapon_", 7) == 0)
+	if (strncmp(STRING(pEntity->pev->classname), "", 7) == 0)
 		return FALSE;
 
 	return TRUE;

--- a/dlls/gungame_gamerules.h
+++ b/dlls/gungame_gamerules.h
@@ -31,6 +31,8 @@ public:
 	virtual BOOL IsAllowedToDropWeapon( void );
 	virtual BOOL IsAllowedToHolsterWeapon( void );
 	virtual int WeaponShouldRespawn( CBasePlayerItem *pWeapon );
+	virtual BOOL CanHavePlayerItem( CBasePlayer *pPlayer, CBasePlayerItem *pWeapon );
+	virtual BOOL CanRandomizeWeapon( const char *name );
 
 private:
 	float m_fGoToIntermission;

--- a/dlls/items.cpp
+++ b/dlls/items.cpp
@@ -305,14 +305,14 @@ class CItemBattery : public CItem
 			return FALSE;
 		}
 
-		if ((pPlayer->pev->armorvalue < MAX_NORMAL_BATTERY) &&
+		if ((pPlayer->pev->armorvalue < pPlayer->pev->max_health) &&
 			(pPlayer->pev->weapons & (1<<WEAPON_SUIT)))
 		{
 			int pct;
 			char szcharge[64];
 
 			pPlayer->pev->armorvalue += gSkillData.batteryCapacity;
-			pPlayer->pev->armorvalue = min(pPlayer->pev->armorvalue, MAX_NORMAL_BATTERY);
+			pPlayer->pev->armorvalue = min(pPlayer->pev->armorvalue, pPlayer->pev->max_health);
 
 			EMIT_SOUND( pPlayer->edict(), CHAN_ITEM, "items/gunpickup2.wav", 1, ATTN_NORM );
 
@@ -323,7 +323,7 @@ class CItemBattery : public CItem
 			
 			// Suit reports new power level
 			// For some reason this wasn't working in release build -- round it.
-			pct = (int)( (float)(pPlayer->pev->armorvalue * 100.0) * (1.0/MAX_NORMAL_BATTERY) + 0.5);
+			pct = (int)( (float)(pPlayer->pev->armorvalue * 100.0) * (1.0/pPlayer->pev->max_health) + 0.5);
 			pct = (pct / 5);
 			if (pct > 0)
 				pct--;

--- a/dlls/jvs_gamerules.cpp
+++ b/dlls/jvs_gamerules.cpp
@@ -601,3 +601,11 @@ int CHalfLifeJesusVsSanta::GetTeamIndex( const char *pTeamName )
 	
 	return -1;	// No match
 }
+
+BOOL CHalfLifeJesusVsSanta::CanRandomizeWeapon( const char *name )
+{
+	if (strcmp(name, "weapon_nuke") == 0)
+		return FALSE;
+
+	return TRUE;
+}

--- a/dlls/jvs_gamerules.cpp
+++ b/dlls/jvs_gamerules.cpp
@@ -507,7 +507,6 @@ void CHalfLifeJesusVsSanta::PlayerSpawn( CBasePlayer *pPlayer )
 		pPlayer->GiveMelees();
 		pPlayer->GiveExplosives();
 		pPlayer->pev->max_health = pPlayer->pev->health = pPlayer->pev->armorvalue = 750;
-		pPlayer->pev->maxspeed = CVAR_GET_FLOAT("sv_maxspeed");
 		g_engfuncs.pfnSetPhysicsKeyValue(pPlayer->edict(), "haste", "1");
 		pPlayer->GiveNamedItem("rune_cloak");
 		strncpy( pPlayer->m_szTeamName, "jesus", TEAM_NAME_LENGTH );
@@ -519,7 +518,6 @@ void CHalfLifeJesusVsSanta::PlayerSpawn( CBasePlayer *pPlayer )
 	else
 	{
 		pPlayer->GiveRandomWeapon("weapon_nuke");
-		pPlayer->pev->maxspeed = CVAR_GET_FLOAT("sv_maxspeed") * .5;
 		strncpy( pPlayer->m_szTeamName, "santa", TEAM_NAME_LENGTH );
 		g_engfuncs.pfnSetClientKeyValue(ENTINDEX(pPlayer->edict()),
 			g_engfuncs.pfnGetInfoKeyBuffer(pPlayer->edict()), "model", "santa");

--- a/dlls/jvs_gamerules.h
+++ b/dlls/jvs_gamerules.h
@@ -29,4 +29,5 @@ public:
 	virtual BOOL CanHavePlayerItem( CBasePlayer *pPlayer, CBasePlayerItem *pWeapon );
 	virtual BOOL IsArmoredMan( CBasePlayer *pPlayer ) { return pArmoredMan == pPlayer; }
 	virtual int GetTeamIndex( const char *pTeamName );
+	virtual BOOL CanRandomizeWeapon( const char *name );
 };

--- a/dlls/multiplay_gamerules.cpp
+++ b/dlls/multiplay_gamerules.cpp
@@ -425,7 +425,7 @@ void CHalfLifeMultiplay :: Think ( void )
 					if (pPlayer && FBitSet(pPlayer->pev->flags, FL_FAKECLIENT))
 					{
 						ALERT(at_aiconsole, "BOT mutator vote!\n");
-						::Vote(pPlayer, RANDOM_LONG(1, MUTATOR_FASTWEAPONS + 2 /*random*/));
+						::Vote(pPlayer, RANDOM_LONG(MUTATOR_CHAOS, MAX_MUTATORS + 1 /*random*/));
 					}
 				}
 			}
@@ -440,13 +440,13 @@ void CHalfLifeMultiplay :: Think ( void )
 				MESSAGE_END();
 
 				// tally votes
-				int vote[MUTATOR_FASTWEAPONS+2]; //+1, +1 RANDOM
+				int vote[MAX_MUTATORS+2]; //+1, +1 RANDOM
 				memset(vote, -1, sizeof(vote));
 
 				for (int j = 1; j <= 32; j++)
 				{
 					int mutatorIndex = g_pGameRules->m_iVoteCount[j-1];
-					if ((mutatorIndex-1) >= 0 && (mutatorIndex-1) <= MUTATOR_FASTWEAPONS + 1 /*random*/)
+					if ((mutatorIndex-1) >= 0 && (mutatorIndex-1) <= MAX_MUTATORS + 1 /*random*/)
 					{
 						if (vote[mutatorIndex-1] == -1) vote[mutatorIndex-1] = 0;
 						vote[mutatorIndex-1]++;
@@ -459,7 +459,7 @@ void CHalfLifeMultiplay :: Think ( void )
 				int fIndex, sIndex, tIndex;
 				fIndex = sIndex = tIndex = -1;
 
-				for (int i = 0; i <= MUTATOR_FASTWEAPONS + 1 /*random*/; i++)
+				for (int i = 0; i <= MAX_MUTATORS + 1 /*random*/; i++)
 				{
 					if (vote[i] > first)
 					{
@@ -494,22 +494,40 @@ void CHalfLifeMultiplay :: Think ( void )
 				}
 				else
 				{
-					if (fIndex == MUTATOR_FASTWEAPONS + 1 /*random*/)
+					if (fIndex == MAX_MUTATORS /*random*/)
 					{
 						UTIL_ClientPrintAll(HUD_PRINTTALK, "[VOTE] Randomizing mutator mode #1...\n");
-						fIndex = RANDOM_LONG(MUTATOR_CHAOS, MUTATOR_FASTWEAPONS);
+						fIndex = RANDOM_LONG(MUTATOR_CHAOS-1, MAX_MUTATORS-1);
+						while ( fIndex == MUTATOR_SLOWMO ||
+								fIndex == MUTATOR_SPEEDUP ||
+								fIndex == MUTATOR_TOPSYTURVY || 
+								fIndex == MUTATOR_EXPLOSIVEAI )
+							fIndex = RANDOM_LONG(MUTATOR_CHAOS-1, MAX_MUTATORS-1);
 					}
 
-					if (sIndex == MUTATOR_FASTWEAPONS + 1 /*random*/)
+					if (sIndex == MAX_MUTATORS /*random*/)
 					{
 						UTIL_ClientPrintAll(HUD_PRINTTALK, "[VOTE] Randomizing mutator mode #2...\n");
-						sIndex = RANDOM_LONG(MUTATOR_CHAOS, MUTATOR_FASTWEAPONS);
+						sIndex = RANDOM_LONG(MUTATOR_CHAOS-1, MAX_MUTATORS-1);
+						while ( sIndex == MUTATOR_SLOWMO ||
+								sIndex == MUTATOR_SPEEDUP ||
+								sIndex == MUTATOR_TOPSYTURVY || 
+								sIndex == MUTATOR_EXPLOSIVEAI ||
+								sIndex == fIndex)
+							sIndex = RANDOM_LONG(MUTATOR_CHAOS-1, MAX_MUTATORS-1);
 					}
 
-					if (tIndex == MUTATOR_FASTWEAPONS + 1 /*random*/)
+					if (tIndex == MAX_MUTATORS /*random*/)
 					{
 						UTIL_ClientPrintAll(HUD_PRINTTALK, "[VOTE] Randomizing mutator mode #3...\n");
-						tIndex = RANDOM_LONG(MUTATOR_CHAOS, MUTATOR_FASTWEAPONS);
+						tIndex = RANDOM_LONG(MUTATOR_CHAOS-1, MAX_MUTATORS-1);
+						while ( tIndex == MUTATOR_SLOWMO ||
+								tIndex == MUTATOR_SPEEDUP ||
+								tIndex == MUTATOR_TOPSYTURVY || 
+								tIndex == MUTATOR_EXPLOSIVEAI ||
+								tIndex == fIndex ||
+								tIndex == sIndex )
+							tIndex = RANDOM_LONG(MUTATOR_CHAOS-1, MAX_MUTATORS-1);
 					}
 
 					ALERT(at_aiconsole, "fIndex=%d, sIndex=%d, tIndex=%d\n", fIndex, sIndex, tIndex);

--- a/dlls/multiplay_gamerules.cpp
+++ b/dlls/multiplay_gamerules.cpp
@@ -171,6 +171,8 @@ void CHalfLifeMultiplay::RefreshSkillData( void )
 		atoi(mutators.string) == MUTATOR_INSTAGIB)
 		gSkillData.plrDmgRailgun = 800;
 
+/*
+	// Not clear to some why weapons did not work
 	if (strstr(mutators.string, g_MutatorPaintball) ||
 		atoi(mutators.string) == MUTATOR_PAINTBALL)
 	{
@@ -197,6 +199,7 @@ void CHalfLifeMultiplay::RefreshSkillData( void )
 		gSkillData.plrDmgFlakBomb *= multiplier;
 		gSkillData.plrDmgPlasma *= multiplier;
 	}
+*/
 
 /*
 	// Reserve for rocket jumping, when we get there.
@@ -1882,10 +1885,9 @@ void CHalfLifeMultiplay :: PlayerThink( CBasePlayer *pPlayer )
 	if (strstr(mutators.string, g_MutatorLightsOut) ||
 		atoi(mutators.string) == MUTATOR_LIGHTSOUT)
 	{
+		// Everready
 		if (pPlayer->IsAlive())
 			pPlayer->m_iFlashBattery = 100;
-		//else
-		//	pPlayer->FlashlightTurnOff();
 	}
 
 	if ( pPlayer->m_fHasRune == RUNE_REGEN )

--- a/dlls/multiplay_gamerules.cpp
+++ b/dlls/multiplay_gamerules.cpp
@@ -1969,6 +1969,7 @@ void CHalfLifeMultiplay :: PlayerThink( CBasePlayer *pPlayer )
 	{
 		if (!pPlayer->IsObserver())
 		{
+			pPlayer->pev->flags &= ~FL_GODMODE;
 			pPlayer->pev->rendermode = kRenderNormal;
 			pPlayer->pev->renderfx = kRenderFxNone;
 			pPlayer->pev->renderamt = 0;
@@ -2099,6 +2100,7 @@ void CHalfLifeMultiplay :: PlayerSpawn( CBasePlayer *pPlayer )
 
 	if (spawnprotectiontime.value > 0)
 	{
+		pPlayer->pev->flags |= FL_GODMODE;
 		pPlayer->pev->solid = SOLID_NOT;
 		pPlayer->m_fEffectTime = gpGlobals->time + 0.25;
 	}

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -4640,7 +4640,7 @@ void CBasePlayer::TraceHitOfSelacoSlide( void )
 					if (pEntity->pev->deadflag != DEAD_FAKING && FBitSet(pEntity->pev->flags, FL_FROZEN)) {
 						pEntity->pev->renderamt = 100;
 						flDamage = 200;
-						::IceExplode(pEntity, DMG_FREEZE);
+						::IceExplode(this, pEntity, DMG_FREEZE);
 					}
 					pEntity->TraceAttack(pev, (gSkillData.plrDmgKick * 4) + flDamage, gpGlobals->v_forward, &tr, DMG_KICK );
 
@@ -4744,7 +4744,7 @@ void CBasePlayer::TraceHitOfSelacoSlide( void )
 					if (pObject->pev->deadflag != DEAD_FAKING && FBitSet(pObject->pev->flags, FL_FROZEN)) {
 						pObject->pev->renderamt = 100;
 						flDamage = 200;
-						::IceExplode(pObject, DMG_FREEZE);
+						::IceExplode(this, pObject, DMG_FREEZE);
 					}
 
 					TraceResult tr;
@@ -4952,7 +4952,7 @@ void CBasePlayer::TraceHitOfFlip( void )
 			if (pObject->pev->deadflag != DEAD_FAKING && FBitSet(pObject->pev->flags, FL_FROZEN)) {
 				pObject->pev->renderamt = 100;
 				flDamage = 200;
-				::IceExplode(pObject, DMG_FREEZE);
+				::IceExplode(this, pObject, DMG_FREEZE);
 			}
 
 			TraceResult tr;
@@ -6612,7 +6612,7 @@ LINK_ENTITY_TO_CLASS( info_intermission, CInfoIntermission );
 extern short g_Gibs;
 extern short g_Steamball;
 
-float IceExplode(CBaseEntity *pEntity, int bitsDamageType)
+float IceExplode(CBaseEntity *pAttacker, CBaseEntity *pEntity, int bitsDamageType)
 {
 	float flAdjustedDamage = 0;
 
@@ -6631,7 +6631,7 @@ float IceExplode(CBaseEntity *pEntity, int bitsDamageType)
 	if (g_pGameRules->IsArmoredMan(((CBasePlayer *)pEntity)))
 		return 0;
 
-	if (!g_pGameRules->FPlayerCanTakeDamage(((CBasePlayer *)pEntity), pEntity))
+	if (!g_pGameRules->FPlayerCanTakeDamage(((CBasePlayer *)pEntity), pAttacker))
 		return 0;
 
 	if (((CBasePlayer *)pEntity)->m_iFreezeCounter < 5)

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -4820,6 +4820,9 @@ void CBasePlayer::StartRightFlip( void )
 	if (!acrobatics.value)
 		return;
 
+	if (pev->waterlevel == 3)
+		return;
+
 	if (m_fFlipTime < gpGlobals->time) {
 		if (FBitSet(pev->flags, FL_ONGROUND)) {
 			UTIL_MakeVectors(pev->angles);
@@ -4837,6 +4840,9 @@ void CBasePlayer::StartRightFlip( void )
 void CBasePlayer::StartLeftFlip( void )
 {
 	if (!acrobatics.value)
+		return;
+
+	if (pev->waterlevel == 3)
 		return;
 
 	if (m_fFlipTime < gpGlobals->time) {
@@ -4857,6 +4863,9 @@ void CBasePlayer::StartBackFlip( void )
 	if (!acrobatics.value)
 		return;
 
+	if (pev->waterlevel == 3)
+		return;
+
 	if (m_fFlipTime < gpGlobals->time) {
 		if (FBitSet(pev->flags, FL_ONGROUND)) {
 			UTIL_MakeVectors(pev->angles);
@@ -4873,6 +4882,9 @@ void CBasePlayer::StartBackFlip( void )
 void CBasePlayer::StartFrontFlip( BOOL addVelocity )
 {
 	if (!acrobatics.value)
+		return;
+
+	if (pev->waterlevel == 3)
 		return;
 
 	if (m_fFlipTime < gpGlobals->time) {
@@ -4892,6 +4904,9 @@ void CBasePlayer::StartFrontFlip( BOOL addVelocity )
 void CBasePlayer::StartHurricaneKick( void )
 {
 	if (!acrobatics.value)
+		return;
+
+	if (pev->waterlevel == 3)
 		return;
 
 	if (m_fFlipTime < gpGlobals->time && pev->velocity.Length2D() > 100) {

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -2696,7 +2696,7 @@ void CBasePlayer::PreThink(void)
 		m_hFlameOwner = NULL;
 	}
 
-	if (m_fNextScreamSound < gpGlobals->time && pev->velocity.z < -600)
+	if (m_fNextScreamSound < gpGlobals->time && pev->velocity.z < -800)
 	{
 		EMIT_SOUND(ENT(pev), CHAN_VOICE, "scientist/scream1.wav", 1, ATTN_NORM);
 		m_fNextScreamSound = gpGlobals->time + 10.0;

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -4190,6 +4190,11 @@ void CBasePlayer::GiveRandomWeapon(const char *szIgnoreList)
 	{
 		random = RANDOM_LONG(0, ARRAYSIZE(pWeapons) - 1);
 	}
+
+	// Nothing for now, sorry.
+	if (!g_pGameRules->CanRandomizeWeapon(pWeapons[random]))
+		return;
+
 	const char *weapon = STRING(ALLOC_STRING(pWeapons[random]));
 	if (!HasNamedPlayerItem(weapon))
 		GiveNamedItem(weapon);

--- a/dlls/player.h
+++ b/dlls/player.h
@@ -492,6 +492,6 @@ public:
 extern int	gmsgHudText;
 extern BOOL gInitHUD;
 
-float IceExplode(CBaseEntity *pEntity, int bitsDamageType) ;
+float IceExplode(CBaseEntity *pAttacker, CBaseEntity *pEntity, int bitsDamageType) ;
 
 #endif // PLAYER_H

--- a/dlls/vest.cpp
+++ b/dlls/vest.cpp
@@ -121,6 +121,11 @@ BOOL CVest::Deploy( )
 
 void CVest::Holster( int skiplocal )
 {
+#ifndef CLIENT_DLL
+	if (allowvoiceovers.value)
+		STOP_SOUND(ENT(m_pPlayer->pev), CHAN_VOICE, "vest_attack.wav");
+	pev->nextthink = -1;
+#endif
 	CBasePlayerWeapon::DefaultHolster(VEST_RADIO_HOLSTER);
 }
 

--- a/dlls/weapons.cpp
+++ b/dlls/weapons.cpp
@@ -2103,6 +2103,11 @@ BOOL CWeaponBox::PackWeapon( CBasePlayerItem *pWeapon )
 		//SetBodygroup(GET_MODEL_PTR(ENT(pev)), pev, 0, WEAPON_ASHPOD - 1);
 		//SetBodygroup(GET_MODEL_PTR(ENT(pev)), pev, 1, WEAPON_ASHPOD - 1);
 	}
+	else if (pWeapon->m_iId == WEAPON_HANDGRENADE)
+	{
+		SET_MODEL( ENT(pev), "models/w_grenade.mdl");
+		pev->sequence = floating;
+	}
 
 	return TRUE;
 }


### PR DESCRIPTION
- Don't show secondary entities in observer
- Improve HUD color swap during ice model change
- Fix protip presisting after map change
- Center mutator icons under radar
- Remove player slow down in JVS and Chilldemic
- No nukes in gungame, jvs, and chilldemic. Prevent spawn
- Make chumtoad nonblocking, improve pickup, remove chumtoad
- Prevent teammates from ice exploding others on same team
- Prevent the dead from receiving give mutators
- Auto toggle flashlight on lightsout mutator (AudioCraZ)
- Remove weapon_ from readouts in GunGame
- Support 999 battery power up
- Remove damage limitation in paintball
- Do not drop fists in gungame
- Increase velocity of fall scream trigger
- No flips under water
- Cancel vest attack on holster
- Fix missing w_ model
- Fix weapon entities in gungame, fix fists once again
- Add do not shoot icon in center, pin to weapons with primary ammo
- Reduce chance of incorrect view model
- Filter out SP mutators in voting, add remaining mutators, improve randomize
- Reduce that odd chance of still walking around after being fragged