### PR TITLE
Dec beta 5 test fixes night 1

### DIFF
--- a/cl_dll/StudioModelRenderer.cpp
+++ b/cl_dll/StudioModelRenderer.cpp
@@ -2044,7 +2044,7 @@ int CStudioModelRenderer::StudioDrawPlayer( int flags, entity_state_t *pplayer )
 		crate = FALSE;
 		int modelindex;
 		m_pRenderModel = gEngfuncs.CL_LoadModel("models/w_weapons.mdl", &modelindex );
-		if (m_pCurrentEntity->curstate.fuser4 > 49)
+		if (m_pCurrentEntity->curstate.fuser4 >= 52)
 		{
 			m_pRenderModel = gEngfuncs.CL_LoadModel("models/w_ammo.mdl", &modelindex );
 		}
@@ -2088,7 +2088,7 @@ int CStudioModelRenderer::StudioDrawPlayer( int flags, entity_state_t *pplayer )
 	
 	if (prophunt)
 	{
-		m_pCurrentEntity->curstate.body = m_pCurrentEntity->curstate.fuser4 >= 50 ? m_pCurrentEntity->curstate.fuser4 - 49 : m_pCurrentEntity->curstate.fuser4;
+		m_pCurrentEntity->curstate.body = m_pCurrentEntity->curstate.fuser4 >= 52 ? m_pCurrentEntity->curstate.fuser4 - 52 : m_pCurrentEntity->curstate.fuser4;
 		m_pCurrentEntity->curstate.skin = gHUD.m_IceModelsIndex;
 		m_pCurrentEntity->origin[2] = m_pCurrentEntity->origin[2] - 36;
 		m_pCurrentEntity->angles = Vector(0,0,0);

--- a/cl_dll/ctfinfo.cpp
+++ b/cl_dll/ctfinfo.cpp
@@ -48,7 +48,7 @@ int CHudCtfInfo::Draw(float flTime)
 	if (gHUD.m_GameMode != GAME_CTF)
 		return 1;
 
-	if (!gHUD.m_Health.m_bitsDamage)
+	if (gHUD.m_Health.m_bitsDamage)
 		return 1;
 
 	if (gHUD.m_Scoreboard.m_iShowscoresHeld)

--- a/cl_dll/entity.cpp
+++ b/cl_dll/entity.cpp
@@ -65,6 +65,14 @@ int CL_DLLEXPORT HUD_AddEntity( int type, struct cl_entity_s *ent, const char *m
 	// each frame every entity passes this function, so the overview hooks 
 	// it to filter the overview entities
 
+	/*
+	// TODO: Replace models here for mutator.
+	cl_entity_s* player = gEngfuncs.GetLocalPlayer();
+	ent->model = player->model;
+	ent->curstate.modelindex = player->curstate.modelindex;
+	ent->curstate.gaitsequence = ent->curstate.sequence;
+	*/
+
 	if ( g_iUser1 )
 	{
 		gHUD.m_Spectator.AddOverviewEntity( type, ent, modelname );

--- a/cl_dll/hl/hl_weapons.cpp
+++ b/cl_dll/hl/hl_weapons.cpp
@@ -1240,14 +1240,19 @@ void HUD_WeaponsPostThink( local_state_s *from, local_state_s *to, usercmd_t *cm
 		 from->client.vuser2[ 2 ] = ( ( CRpg * )player.m_pActiveItem)->m_cActiveRockets;
 	}
 
+	static float stime = 0;
+	if (stime - 2 > time)
+		stime = 0;
+
 	// Barrel smoke
 	if (pWeapon && (pWeapon->m_iId == WEAPON_SAWEDOFF || pWeapon->m_iId == WEAPON_DUAL_SAWEDOFF) && 
 		(pWeapon->m_flNextPrimaryAttack > 0 || pWeapon->m_flNextSecondaryAttack > 0))
 	{
 		if (!CL_IsThirdPerson())
 		{
-			if (cl_gunsmoke && cl_gunsmoke->value)
+			if (cl_gunsmoke && cl_gunsmoke->value && stime < time)
 			{
+				stime = time + 0.1;
 				static TEMPENTITY *t[16];
 				static int c = 0;
 				int model = gEngfuncs.pEventAPI->EV_FindModelIndex( "sprites/gunsmoke.spr" );
@@ -1281,8 +1286,9 @@ void HUD_WeaponsPostThink( local_state_s *from, local_state_s *to, usercmd_t *cm
 	{
 		if (!CL_IsThirdPerson())
 		{
-			if (cl_gunsmoke && cl_gunsmoke->value)
+			if (cl_gunsmoke && cl_gunsmoke->value && stime < time)
 			{
+				stime = time + 0.1;
 				static TEMPENTITY *t[16];
 				static int c = 0;
 				int model = gEngfuncs.pEventAPI->EV_FindModelIndex( "sprites/gunsmoke.spr" );

--- a/cl_dll/hud_msg.cpp
+++ b/cl_dll/hud_msg.cpp
@@ -454,6 +454,12 @@ void CHud :: MsgFunc_FlameMsg( const char *pszName, int iSize, void *pbuf )
 
 	n = READ_SHORT();
 	s = READ_BYTE();
+
+	cl_entity_t *local = gEngfuncs.GetLocalPlayer();
+	if (gHUD.m_GameMode == GAME_CHILLDEMIC &&
+		local->curstate.fuser4 > 0 &&
+		(local->index) == n)
+		return;
 	
 	FlameSystem.SetState(n, s);
 }

--- a/cl_dll/hud_redraw.cpp
+++ b/cl_dll/hud_redraw.cpp
@@ -351,7 +351,7 @@ int CHud :: Redraw( float flTime, int intermission )
 	{
 		if (m_fPlayerDeadTime && m_fPlayerDeadTime > gEngfuncs.GetClientTime())
 		{
-			int max = ScreenWidth / 2, height = 18, w = 0, h = 0;
+			int max = fmin(ScreenWidth / 2, 350), height = 18, w = 0, h = 0;
 			float timeLeft = fmin((m_fPlayerDeadTime - gEngfuncs.GetClientTime()) * 100, max);
 			char message[64];
 			sprintf(message, "Can respawn in %d ...\n",  (int)m_fPlayerDeadTime - (int)gEngfuncs.GetClientTime());

--- a/cl_dll/scoreboard.cpp
+++ b/cl_dll/scoreboard.cpp
@@ -155,12 +155,12 @@ int CHudScoreboard :: Draw( float fTime )
 		gHUD.DrawHudStringReverse( KILLS_RANGE_MAX + xpos_rel, ypos, 0, "Lives", r, g, b );
 	else if (gHUD.m_Teamplay == GAME_GUNGAME)
 		gHUD.DrawHudStringReverse( KILLS_RANGE_MAX + xpos_rel, ypos, 0, "Level", r, g, b );
-	else if (gHUD.m_Teamplay == GAME_CTC || gHUD.m_Teamplay == GAME_PROPHUNT)
+	else if (gHUD.m_Teamplay == GAME_PROPHUNT)
 		gHUD.DrawHudStringReverse( KILLS_RANGE_MAX + xpos_rel, ypos, 0, "Points", r, g, b );
 	else if (gHUD.m_Teamplay == GAME_COLDSKULL)
 		gHUD.DrawHudStringReverse( KILLS_RANGE_MAX + xpos_rel, ypos, 0, "Skulls", r, g, b );
 	else
-		gHUD.DrawHudStringReverse( KILLS_RANGE_MAX + xpos_rel, ypos, 0, "K ills", r, g, b );
+		gHUD.DrawHudStringReverse( KILLS_RANGE_MAX + xpos_rel, ypos, 0, "Frags", r, g, b );
 	gHUD.DrawHudString( DIVIDER_POS + xpos_rel, ypos, ScreenWidth, "/", r, g, b );
 	gHUD.DrawHudString( DEATHS_RANGE_MIN + xpos_rel + 5, ypos, ScreenWidth, "Deaths", r, g, b );
 	if (ScoreBased())

--- a/cl_dll/util.cpp
+++ b/cl_dll/util.cpp
@@ -166,6 +166,7 @@ bool ScoreBased( void )
 			gHUD.m_Teamplay == GAME_BUSTERS ||
 			gHUD.m_Teamplay == GAME_CHILLDEMIC ||
 			gHUD.m_Teamplay == GAME_COLDSPOT ||
+			gHUD.m_Teamplay == GAME_CTC ||
 			gHUD.m_Teamplay == GAME_CTF ||
 			gHUD.m_Teamplay == GAME_HORDE ||
 			gHUD.m_Teamplay == GAME_ICEMAN ||

--- a/cl_dll/vgui_VoteMutatorWindow.cpp
+++ b/cl_dll/vgui_VoteMutatorWindow.cpp
@@ -139,6 +139,33 @@ void CVoteMutatorPanel::Update()
 		}
 	}
 
+	int second = -1, s = -1;
+
+	for ( int i = 0; i < MAX_MUTATORS; i++ )
+	{
+		for ( int j = 1; j <= MAX_PLAYERS; j++ )
+		{
+			if (second < votes[i] && second <= highest && i != hi)
+			{
+				second = votes[i];
+				s = i;
+			}
+		}
+	}
+
+	int third = -1, t = -1;
+	for ( int i = 0; i < MAX_MUTATORS; i++ )
+	{
+		for ( int j = 1; j <= MAX_PLAYERS; j++ )
+		{
+			if (third < votes[i] && third <= second && i != hi && i != s)
+			{
+				third = votes[i];
+				t = i;
+			}
+		}
+	}
+
 	for ( int i = 0; i < MAX_MUTATORS; i++ )
 	{
 		if (m_pButtons[i])
@@ -159,7 +186,7 @@ void CVoteMutatorPanel::Update()
 			if (votes[i] > 0)
 			{
 				m_pButtons[i]->setArmed(true);
-				if (votes[i] == highest)
+				if (i == hi || i == s || i == t)
 				{
 					m_pButtons[i]->setBorder(new LineBorder(Color(255, 255, 255, a)));
 					m_pButtons[i]->setBgColor(r, g, b, 0);

--- a/cl_dll/view.cpp
+++ b/cl_dll/view.cpp
@@ -2293,6 +2293,10 @@ void V_IronSight( Vector position, Vector punch, float clientTime, float frameTi
 	if (!strncmp(viewModel->model->name, "models/v_dual_", strlen("models/v_dual_")))
 		return;
 
+	// Needs second attachment for flames, disale for now.
+	if (!strncmp(viewModel->model->name, "models/v_flamethrower", strlen("models/v_flamethrower")))
+		return;
+
 	if (CL_IsThirdPerson())
 		return;
 

--- a/cl_dll/view.cpp
+++ b/cl_dll/view.cpp
@@ -798,6 +798,25 @@ void V_CalcNormalRefdef ( struct ref_params_s *pparams )
 		}
 	}
 
+/*
+	// running hold down viewmodel
+	float holdTarget = 0;
+	float holdTargetYaw = 0;
+	if (fabs(pparams->simvel[0]) > 150 || fabs(pparams->simvel[1]) > 150)
+	{
+		holdTarget = -20;
+		holdTargetYaw = 25 * (90 - fabs(pparams->viewangles[PITCH])) / 90;
+	}
+
+	static float lerpedHold = 0;
+	static float lerpedHoldYaw = 0;
+	lerpedHold = lerp(lerpedHold, holdTarget, gHUD.m_flTimeDelta * 3.0f);
+	lerpedHoldYaw = lerp(lerpedHoldYaw, holdTargetYaw, gHUD.m_flTimeDelta * 3.0f);
+
+	view->angles[PITCH] += lerpedHold;
+	view->angles[YAW] += lerpedHoldYaw;
+*/
+
 	if (gEngfuncs.GetMaxClients() == 1)
 	{
 		if (MutatorEnabled(MUTATOR_TOPSYTURVY) &&

--- a/dlls/cbase.h
+++ b/dlls/cbase.h
@@ -249,9 +249,12 @@ public:
 	// common member functions
 	void EXPORT SUB_Remove( void );
 	void EXPORT SUB_DoNothing( void );
+	void EXPORT SUB_StartFadeIn ( void );
+	void EXPORT SUB_FadeIn ( void );
 	void EXPORT SUB_StartFadeOut ( void );
 	void EXPORT SUB_FadeOut ( void );
 	void EXPORT SUB_FadeOutFast ( void );
+	void EXPORT SUB_FadeOutFast_NoRemove ( void );
 	void EXPORT SUB_CallUseToggle( void ) { this->Use( this, this, USE_TOGGLE, 0 ); }
 	int			ShouldToggle( USE_TYPE useType, BOOL currentState );
 	void		FireBullets( ULONG	cShots, Vector  vecSrc, Vector	vecDirShooting,	Vector	vecSpread, float flDistance, int iBulletType, int iTracerFreq = 4, int iDamage = 0, entvars_t *pevAttacker = NULL  );

--- a/dlls/chilldemic_gamerules.cpp
+++ b/dlls/chilldemic_gamerules.cpp
@@ -740,6 +740,15 @@ BOOL CHalfLifeChilldemic::CanHavePlayerItem( CBasePlayer *pPlayer, CBasePlayerIt
 	if (!strcmp(STRING(pItem->pev->classname), "weapon_nuke"))
 		return FALSE;
 
+	if (pPlayer->pev->fuser4 > 0 &&
+		strcmp(STRING(pItem->pev->classname), "weapon_fists") &&
+		strcmp(STRING(pItem->pev->classname), "weapon_chainsaw") &&
+		strcmp(STRING(pItem->pev->classname), "weapon_knife") &&
+		strcmp(STRING(pItem->pev->classname), "weapon_crowbar") &&
+		strcmp(STRING(pItem->pev->classname), "weapon_wrench") &&
+		strcmp(STRING(pItem->pev->classname), "weapon_dual_wrench"))
+		return FALSE;
+
 	return CHalfLifeMultiplay::CanHavePlayerItem( pPlayer, pItem );
 }
 

--- a/dlls/coldskull_gamerules.cpp
+++ b/dlls/coldskull_gamerules.cpp
@@ -59,7 +59,7 @@ void CSkullCharm::Spawn( void )
 	pev->angles.z = 0;
 	pev->movetype = MOVETYPE_TOSS;
 	pev->solid = SOLID_NOT;
-	UTIL_SetSize(pev, Vector(0, 0, 0), Vector(0, 0, 0));
+	UTIL_SetSize( pev, g_vecZero, g_vecZero );
 	UTIL_SetOrigin( pev, pev->origin );
 
 	SetTouch( &CSkullCharm::SkullTouch );
@@ -75,7 +75,14 @@ void CSkullCharm::Spawn( void )
 void CSkullCharm::ThinkSolid( void )
 {
 	pev->solid = SOLID_TRIGGER;
-	UTIL_SetSize(pev, Vector(-16, -16, 0), Vector(16, 16, 16));
+	UTIL_SetSize( pev, g_vecZero, g_vecZero );
+
+	// place in player spot if it falls out.
+	TraceResult trace;
+	UTIL_TraceHull(pev->origin, pev->origin, dont_ignore_monsters, head_hull, edict(), &trace );
+	if (trace.fStartSolid)
+		UTIL_SetOrigin(pev, pev->vuser1);
+
 	SetThink( &CBaseEntity::SUB_StartFadeOut );
 	pev->nextthink = gpGlobals->time + 25.0;
 }
@@ -180,6 +187,8 @@ void CreateSkull( CBasePlayer *pVictim, int amount )
 		pSkull->pev->velocity.y = RANDOM_FLOAT( -300, 300 );
 		pSkull->pev->velocity.z = RANDOM_FLOAT( 0, 300 );
 		pSkull->pev->fuser1 = amount;
+		pSkull->pev->vuser1 = pVictim->pev->origin;
+		pSkull->pev->vuser1.z -= 32;
 
 		/*
 		1 - Bronze Skull

--- a/dlls/coldspot_gamerules.cpp
+++ b/dlls/coldspot_gamerules.cpp
@@ -251,9 +251,14 @@ void CHalfLifeColdSpot::InitHUD( CBasePlayer *pPlayer )
 	}
 }
 
+extern DLL_GLOBAL BOOL g_fGameOver;
+
 void CHalfLifeColdSpot::Think( void )
 {
 	CHalfLifeMultiplay::Think();
+
+	if ( g_fGameOver )
+		return;
 
 	if (coldspottime.value != m_fColdSpotTime)
 		m_fColdSpotTime = m_fSpawnColdSpot = coldspottime.value;

--- a/dlls/combat.cpp
+++ b/dlls/combat.cpp
@@ -779,6 +779,59 @@ void CBaseEntity :: SUB_FadeOutFast ( void  )
 	}
 }
 
+void CBaseEntity :: SUB_FadeOutFast_NoRemove ( void )
+{
+	if (pev->renderfx == kRenderFxGlowShell)
+		pev->renderfx = kRenderFxNone;
+
+	if (pev->rendermode == kRenderNormal)
+	{
+		pev->renderamt = 255;
+		pev->rendermode = kRenderTransTexture;
+	}
+
+	if ( pev->renderamt > 0 )
+	{
+		pev->renderamt -= 3;
+		//pev->nextthink = gpGlobals->time + 0.1;
+	}
+	else
+	{
+		pev->renderamt = 0;
+		//pev->nextthink = -1;
+	}
+}
+
+void CBaseEntity :: SUB_StartFadeIn ( void )
+{
+	//if (pev->rendermode == kRenderNormal)
+	{
+		pev->renderamt = 0;
+		pev->rendermode = kRenderTransAdd;
+	}
+
+	//pev->solid = SOLID_NOT;
+	//pev->avelocity = g_vecZero;
+
+	pev->nextthink = gpGlobals->time + 0.1;
+	SetThink ( &CBaseEntity::SUB_FadeIn );
+}
+
+void CBaseEntity :: SUB_FadeIn ( void )
+{
+	if ( pev->renderamt < 255 )
+	{
+		pev->renderamt += 7;
+		pev->nextthink = gpGlobals->time + 0.1;
+	}
+	else 
+	{
+		pev->renderamt = 255;
+		pev->nextthink = gpGlobals->time + 0.2;
+		SetThink ( &CBaseEntity::SUB_DoNothing );
+	}
+}
+
 //=========================================================
 // WaitTillLand - in order to emit their meaty scent from
 // the proper location, gibs should wait until they stop 

--- a/dlls/combat.cpp
+++ b/dlls/combat.cpp
@@ -473,8 +473,6 @@ Activity CBaseMonster :: GetDeathActivity ( void )
 		switch ( m_LastHitGroup )
 		{
 			case HITGROUP_HEAD:
-			case HITGROUP_CHEST:
-			case HITGROUP_GENERIC:
 				CGib::SpawnHeadGib( pev, TRUE );
 				SetBodygroup( 0, 1 );
 				deathActivity = ACT_DIE_HEADSHOT;

--- a/dlls/ctc_gamerules.cpp
+++ b/dlls/ctc_gamerules.cpp
@@ -535,5 +535,8 @@ BOOL CHalfLifeCaptureTheChumtoad::MutatorAllowed(const char *mutator)
 	if (strstr(mutator, g_szMutators[MUTATOR_NOCLIP - 1]) || atoi(mutator) == MUTATOR_NOCLIP)
 		return FALSE;
 
+	if (strstr(mutator, g_szMutators[MUTATOR_DONTSHOOT - 1]) || atoi(mutator) == MUTATOR_DONTSHOOT)
+		return FALSE;
+
 	return CHalfLifeMultiplay::MutatorAllowed(mutator);
 }

--- a/dlls/ctc_gamerules.cpp
+++ b/dlls/ctc_gamerules.cpp
@@ -281,12 +281,24 @@ CBaseEntity *CHalfLifeCaptureTheChumtoad::DropCharm( CBasePlayer *pPlayer, Vecto
 	return pChumtoad;
 }
 
+extern DLL_GLOBAL BOOL g_fGameOver;
+
 void CHalfLifeCaptureTheChumtoad::PlayerThink( CBasePlayer *pPlayer )
 {
 	CHalfLifeMultiplay::PlayerThink(pPlayer);
 
 	if (m_flIntermissionEndTime)
 		return;
+
+	if (!g_fGameOver)
+	{
+		// End session if hit round limit
+		if ( pPlayer->m_iRoundWins >= scorelimit.value )
+		{
+			GoToIntermission();
+			return;
+		}
+	}
 
 	// Updates once per second
 	int time_remaining = (int)gpGlobals->time;
@@ -302,7 +314,7 @@ void CHalfLifeCaptureTheChumtoad::PlayerThink( CBasePlayer *pPlayer )
 			{
 				pPlayer->m_iChumtoadCounter++;
 				message = UTIL_VarArgs("Running with the Chumtoad!\nPoints: %d | Timer: %d", 
-						(int)pPlayer->pev->frags, pPlayer->m_iChumtoadCounter);
+						(int)pPlayer->m_iRoundWins, pPlayer->m_iChumtoadCounter);
 				scoringPoints = TRUE;
 			}
 			else
@@ -324,12 +336,12 @@ void CHalfLifeCaptureTheChumtoad::PlayerThink( CBasePlayer *pPlayer )
 				int secondsUntilPoint = ctcsecondsforpoint.value > 0 ? ctcsecondsforpoint.value : 10;
 				if (pPlayer->m_iChumtoadCounter % secondsUntilPoint == 0)
 				{
-					pPlayer->pev->frags++;
+					pPlayer->m_iRoundWins++;
 					MESSAGE_BEGIN( MSG_ALL, gmsgScoreInfo );
 						WRITE_BYTE( ENTINDEX(pPlayer->edict()) );
 						WRITE_SHORT( pPlayer->pev->frags );
 						WRITE_SHORT( pPlayer->m_iDeaths );
-						WRITE_SHORT( 0 );
+						WRITE_SHORT( pPlayer->m_iRoundWins );
 						WRITE_SHORT( 0 );
 					MESSAGE_END();
 
@@ -518,6 +530,9 @@ BOOL CHalfLifeCaptureTheChumtoad::ShouldAutoAim( CBasePlayer *pPlayer, edict_t *
 BOOL CHalfLifeCaptureTheChumtoad::MutatorAllowed(const char *mutator)
 {
 	if (strstr(mutator, g_szMutators[MUTATOR_CHUMXPLODE - 1]) || atoi(mutator) == MUTATOR_CHUMXPLODE)
+		return FALSE;
+
+	if (strstr(mutator, g_szMutators[MUTATOR_NOCLIP - 1]) || atoi(mutator) == MUTATOR_NOCLIP)
 		return FALSE;
 
 	return CHalfLifeMultiplay::MutatorAllowed(mutator);

--- a/dlls/ctf_gamerules.cpp
+++ b/dlls/ctf_gamerules.cpp
@@ -626,6 +626,8 @@ void CHalfLifeCaptureTheFlag::PlayerSpawn( CBasePlayer *pPlayer )
 	CHalfLifeMultiplay::SavePlayerModel(pPlayer);
 }
 
+extern DLL_GLOBAL BOOL g_fGameOver;
+
 void CHalfLifeCaptureTheFlag::ClientUserInfoChanged( CBasePlayer *pPlayer, char *infobuffer )
 {
 	// prevent skin/color/model changes
@@ -633,7 +635,14 @@ void CHalfLifeCaptureTheFlag::ClientUserInfoChanged( CBasePlayer *pPlayer, char 
 	char *mdls = g_engfuncs.pfnInfoKeyValue( infobuffer, "model" );
 	int clientIndex = pPlayer->entindex();
 
+	if ( !pPlayer->m_szTeamName || !strlen(pPlayer->m_szTeamName) )
+		return;
+
 	if ( !stricmp( mdls, pPlayer->m_szTeamName ) )
+		return;
+
+	// Ignore ctf on model changing back.
+	if ( g_fGameOver )
 		return;
 
 	// prevent skin/color/model changes

--- a/dlls/disc.cpp
+++ b/dlls/disc.cpp
@@ -282,7 +282,20 @@ void CDisc::DiscTouch ( CBaseEntity *pOther )
 					if ( m_bTeleported )
 						((CBasePlayer*)pOther)->m_flLastDiscHitTeleport = gpGlobals->time;
 
-					pOther->TakeDamage(pev, m_hOwner->pev, gSkillData.plrDmgCrowbar, DMG_SLASH);
+					UTIL_MakeVectors(pev->angles);
+					TraceResult tr;
+					Vector vecEnd = pev->origin + gpGlobals->v_forward * 32;
+					UTIL_TraceLine(pev->origin, vecEnd, dont_ignore_monsters, ENT(m_hOwner->pev), &tr);
+					
+					ClearMultiDamage();
+					pOther->TraceAttack(m_hOwner->pev, gSkillData.plrDmgCrowbar, gpGlobals->v_forward, &tr, DMG_SLASH);
+					ApplyMultiDamage(pev, m_hOwner->pev);
+
+					if (tr.iHitgroup == HITGROUP_HEAD)
+					{
+						((CBasePlayer*)pOther)->pev->health = 0; // without this, player can walk as a ghost.
+						((CBasePlayer*)pOther)->Killed(m_hOwner->pev, GIB_NEVER);
+					}
 
 					m_fDontTouchEnemies = gpGlobals->time + 2.0;
 				}

--- a/dlls/disc.cpp
+++ b/dlls/disc.cpp
@@ -90,10 +90,7 @@ void CDisc::Spawn( void )
 	pev->solid = SOLID_TRIGGER;
 
 	// Setup model
-	//if ( m_iPowerupFlags & POW_HARD )
-	//	SET_MODEL(ENT(pev), "models/disc_hard.mdl");
-	//else
-		SET_MODEL(ENT(pev), "models/w_grenade.mdl");
+	SET_MODEL(ENT(pev), "models/w_grenade.mdl");
     pev->body = 1;
 	UTIL_SetSize(pev, Vector( -4,-4,-4 ), Vector(4, 4, 4));
 
@@ -157,17 +154,14 @@ void CDisc::Spawn( void )
 void CDisc::Precache( void )
 {
 	PRECACHE_MODEL("models/w_grenade.mdl");
-	//PRECACHE_MODEL("models/disc_hard.mdl");
 	PRECACHE_SOUND("weapons/cbar_hitbod1.wav");
 	PRECACHE_SOUND("weapons/cbar_hitbod2.wav");
 	PRECACHE_SOUND("weapons/cbar_hitbod3.wav");
-	//PRECACHE_SOUND("weapons/altfire.wav");
 	PRECACHE_SOUND("items/gunpickup2.wav");
 	PRECACHE_SOUND("weapons/electro5.wav");
 	PRECACHE_SOUND("weapons/xbow_hit1.wav");
 	PRECACHE_SOUND("weapons/xbow_hit2.wav");
 	PRECACHE_SOUND("weapons/rocket1.wav");
-	//PRECACHE_SOUND("dischit.wav");
 	m_iTrail = PRECACHE_MODEL("sprites/smoke.spr");
 	m_iSpriteTexture = PRECACHE_MODEL( "sprites/lgtning.spr" );
 }

--- a/dlls/disc.cpp
+++ b/dlls/disc.cpp
@@ -113,6 +113,8 @@ void CDisc::Spawn( void )
 	//else
 		pev->velocity = gpGlobals->v_forward * DISC_VELOCITY;
 
+	pev->angles = UTIL_VecToAngles(pev->velocity);
+
 	// Pull our owner out so we will still touch it
 	if ( pev->owner )
 		m_hOwner = Instance(pev->owner);
@@ -129,7 +131,7 @@ void CDisc::Spawn( void )
 	else
 		WRITE_BYTE( 3 ); // life
 
-		WRITE_BYTE( 5 );  // width
+		WRITE_BYTE( 3 );  // width
 
 		WRITE_BYTE( g_iaDiscColors[pev->team][0] ); // r, g, b
 		WRITE_BYTE( g_iaDiscColors[pev->team][1] ); // r, g, b
@@ -146,7 +148,7 @@ void CDisc::Spawn( void )
 	pev->renderfx = kRenderFxGlowShell;
 	for (int i = 0; i <= 2;i ++)
 		pev->rendercolor[i] = g_iaDiscColors[pev->team][i];
-	pev->renderamt = 100;
+	pev->renderamt = 10;
 
 	pev->nextthink = gpGlobals->time + 0.1;
 }
@@ -320,6 +322,7 @@ void CDisc::DiscTouch ( CBaseEntity *pOther )
 		}
 
 		UTIL_Sparks( pev->origin );
+		pev->angles = UTIL_VecToAngles(pev->velocity);
 	}
 }
 

--- a/dlls/gamerules.cpp
+++ b/dlls/gamerules.cpp
@@ -778,8 +778,6 @@ void CGameRules::SpawnMutators(CBasePlayer *pPlayer)
 		{
 			pPlayer->pev->body = 0;
 			pPlayer->SetBodygroup( 2, 1 );
-			//pPlayer->m_EFlags &= ~EFLAG_CANCEL;
-			//pPlayer->m_EFlags |= EFLAG_JEEP;
 		}
 	}
 

--- a/dlls/gamerules.cpp
+++ b/dlls/gamerules.cpp
@@ -916,6 +916,14 @@ void CGameRules::GiveMutators(CBasePlayer *pPlayer)
 		if (!pPlayer->m_fLongJump && (pPlayer->pev->weapons & (1<<WEAPON_SUIT)))
 			pPlayer->GiveNamedItem("item_longjump");
 	}
+
+	if (MutatorEnabled(MUTATOR_GODMODE)) {
+		if (!pPlayer->HasNamedPlayerItem("weapon_vice"))
+		{
+			pPlayer->GiveNamedItem("weapon_vice");
+			pPlayer->SelectItem("weapon_vice");
+		}
+	}
 }
 
 const char *entityList[] =

--- a/dlls/gamerules.cpp
+++ b/dlls/gamerules.cpp
@@ -1408,7 +1408,7 @@ void CGameRules::MutatorsThink(void)
 							UTIL_SetOrigin(pl->pev, VARS(pentSpawnSpot)->origin + Vector(0,0,1));
 							pl->pev->angles = VARS(pentSpawnSpot)->angles;
 							CBaseEntity *ent = NULL;
-							while ( (ent = UTIL_FindEntityInSphere( ent, pl->pev->origin, 128 )) != NULL )
+							while ( (ent = UTIL_FindEntityInSphere( ent, pl->pev->origin, 64 )) != NULL )
 							{
 								// if ent is a client, kill em (unless they are ourselves)
 								if ( ent->IsPlayer() && !(ent->edict() == pentSpawnSpot) && ent->IsAlive() && !ent->pev->iuser1 )

--- a/dlls/gamerules.cpp
+++ b/dlls/gamerules.cpp
@@ -1411,7 +1411,7 @@ void CGameRules::MutatorsThink(void)
 							while ( (ent = UTIL_FindEntityInSphere( ent, pl->pev->origin, 64 )) != NULL )
 							{
 								// if ent is a client, kill em (unless they are ourselves)
-								if ( ent->IsPlayer() && !(ent->edict() == pentSpawnSpot) && ent->IsAlive() && !ent->pev->iuser1 )
+								if ( ent->IsPlayer() && ent->IsAlive() && ent->edict() != pl->edict() && !ent->pev->iuser1 )
 								{
 									ClearMultiDamage();
 									ent->pev->health = 0; // without this, player can walk as a ghost.

--- a/dlls/gamerules.cpp
+++ b/dlls/gamerules.cpp
@@ -724,8 +724,9 @@ BOOL CGameRules::WeaponMutators( CBasePlayerWeapon *pWeapon )
 
 			if (MutatorEnabled(MUTATOR_PUSHY))
 			{
+				pWeapon->m_pPlayer->pev->flags &= ~FL_ONGROUND;
 				UTIL_MakeVectors( pWeapon->m_pPlayer->pev->v_angle );
-				pWeapon->m_pPlayer->pev->velocity = pWeapon->m_pPlayer->pev->velocity - gpGlobals->v_forward * RANDOM_FLOAT(50,100) * 5;
+				pWeapon->m_pPlayer->pev->velocity = pWeapon->m_pPlayer->pev->velocity - gpGlobals->v_forward * RANDOM_FLOAT(50,100) * 3;
 			}
 		}
 	}

--- a/dlls/ggrenade.cpp
+++ b/dlls/ggrenade.cpp
@@ -517,6 +517,7 @@ CGrenade * CGrenade:: ShootTimed( entvars_t *pevOwner, Vector vecStart, Vector v
 	}
 
 	SET_MODEL(ENT(pGrenade->pev), "models/w_grenade.mdl");
+	pGrenade->pev->body = 0;
 	pGrenade->pev->sequence = RANDOM_LONG( 4, 7 );
 	pGrenade->pev->framerate = 1.0;
 	pGrenade->ResetSequenceInfo();
@@ -618,6 +619,7 @@ CGrenade *CGrenade::ShootTimedCluster( entvars_t *pevOwner, Vector vecStart, Vec
     pGrenade->pev->friction = 0.8;
 
     SET_MODEL(ENT(pGrenade->pev), "models/w_grenade.mdl");
+	pGrenade->pev->body = 0;
     pGrenade->pev->dmg = gSkillData.plrDmgClusterGrenade;
 
     return pGrenade;

--- a/dlls/horde_gamerules.cpp
+++ b/dlls/horde_gamerules.cpp
@@ -923,3 +923,19 @@ BOOL CHalfLifeHorde::IsRoundBased( void )
 {
 	return TRUE;
 }
+
+BOOL CHalfLifeHorde::CanHavePlayerItem( CBasePlayer *pPlayer, CBasePlayerItem *pItem )
+{
+	if (!strcmp(STRING(pItem->pev->classname), "weapon_nuke"))
+		return FALSE;
+
+	return CHalfLifeMultiplay::CanHavePlayerItem( pPlayer, pItem );
+}
+
+BOOL CHalfLifeHorde::CanRandomizeWeapon( const char *name )
+{
+	if (strcmp(name, "weapon_nuke") == 0)
+		return FALSE;
+
+	return TRUE;
+}

--- a/dlls/horde_gamerules.h
+++ b/dlls/horde_gamerules.h
@@ -34,6 +34,8 @@ public:
 	virtual void MonsterKilled( CBaseMonster *pVictim, entvars_t *pKiller );
 	virtual BOOL ShouldAutoAim( CBasePlayer *pPlayer, edict_t *target );
 	virtual BOOL IsRoundBased( void );
+	virtual BOOL CanHavePlayerItem( CBasePlayer *pPlayer, CBasePlayerItem *pItem );
+	virtual BOOL CanRandomizeWeapon( const char *name );
 
 private:
 	int m_iSurvivorsRemain;

--- a/dlls/multiplay_gamerules.cpp
+++ b/dlls/multiplay_gamerules.cpp
@@ -759,6 +759,7 @@ void CHalfLifeMultiplay :: Think ( void )
 	float flTimeLimit = timelimit.value * 60;
 	float flFragLimit = fraglimit.value;
 	if (g_GameMode == GAME_BUSTERS ||
+		g_GameMode == GAME_CTC ||
 		g_GameMode == GAME_CTF ||
 		g_GameMode == GAME_COLDSPOT ||
 		g_GameMode == GAME_GUNGAME)

--- a/dlls/multiplay_gamerules.cpp
+++ b/dlls/multiplay_gamerules.cpp
@@ -257,6 +257,7 @@ char *gamePlayModes[] = {
 	"Busters",
 	"Chilldemic",
 	"Cold Skulls",
+	"Cold Spot",
 	"Capture The Chumtoad",
 	"Capture The Flag",
 	"GunGame",
@@ -493,21 +494,24 @@ void CHalfLifeMultiplay :: Think ( void )
 
 				int highest = -9999;
 				int gameIndex = GAME_FFA;
-				int tie = -9999;
 				for (int i = 0; i <= TOTAL_GAME_MODES + 1 /*random*/; i++)
 				{
 					if (highest <= vote[i])
 					{
-						if (highest == vote[i])
-							tie = highest;
-						highest = vote[i];
-						gameIndex = i;
+						// Tie, determine random if this index should be selected instead.
+						if (highest == vote[i]) {
+							if (RANDOM_LONG(0, 1)) {
+								gameIndex = i;
+							}
+						}
+						else
+						{
+							highest = vote[i];
+							gameIndex = i;
+						}
 						// ALERT(at_console, "highest=%d, vote[i]=%d, gameIndex=%d\n", highest, vote[i], gameIndex);
 					}
 				}
-
-				if (highest == tie)
-					gameIndex = TOTAL_GAME_MODES + 1; // randomize!
 
 				memset(m_iVoteCount, -1, sizeof(m_iVoteCount));
 
@@ -709,21 +713,24 @@ void CHalfLifeMultiplay :: Think ( void )
 
 				int highest = -9999;
 				int mapIndex = 0;
-				int tie = -9999;
 				for (int i = 0; i < BUILT_IN_MAP_COUNT + 1 /*random*/; i++)
 				{
 					if (highest <= vote[i])
 					{
-						if (highest == vote[i])
-							tie = highest;
-						highest = vote[i];
-						m_iDecidedMapIndex = mapIndex = i;
+						// Tie, determine random if this index should be selected instead.
+						if (highest == vote[i]) {
+							if (RANDOM_LONG(0, 1)) {
+								m_iDecidedMapIndex = mapIndex = i;
+							}
+						}
+						else
+						{
+							highest = vote[i];
+							m_iDecidedMapIndex = mapIndex = i;
+						}
 						// ALERT(at_console, "highest=%d, vote[i]=%d, mapIndex=%d\n", highest, vote[i], mapIndex);
 					}
 				}
-
-				if (highest == tie)
-					m_iDecidedMapIndex = BUILT_IN_MAP_COUNT; // randomize if tied!
 
 				if (highest <= 0)
 				{

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -3815,7 +3815,7 @@ edict_t *EntSelectSpawnPoint( CBaseEntity *pPlayer )
 		if ( !FNullEnt( pSpot ) )
 		{
 			CBaseEntity *ent = NULL;
-			while ( (ent = UTIL_FindEntityInSphere( ent, pSpot->pev->origin, 128 )) != NULL )
+			while ( (ent = UTIL_FindEntityInSphere( ent, pSpot->pev->origin, 64 )) != NULL )
 			{
 				// if ent is a client, kill em (unless they are ourselves)
 				if ( ent->IsPlayer() && !(ent->edict() == player) && ent->IsAlive() && !ent->pev->iuser1 )

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -1382,7 +1382,8 @@ void CBasePlayer::SetAnimation( PLAYER_ANIM playerAnim )
 
 	if (g_pGameRules->IsPropHunt() && pev->fuser4 > 0)
 	{
-		int ideal = pev->fuser4 >= 50 ? ((pev->fuser4 - 49) * 2) + floatingweapons.value : (pev->fuser4 * 2) + floatingweapons.value;
+		int maxWeaponModels = 52; //dual handg
+		int ideal = pev->fuser4 >= maxWeaponModels ? ((pev->fuser4 - maxWeaponModels) * 2) + floatingweapons.value : (pev->fuser4 * 2) + floatingweapons.value;
 		if (pev->sequence == ideal)
 			return;
 

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -4213,6 +4213,13 @@ void CBasePlayer::SelectItem(const char *pstr)
 
 	ResetAutoaim( );
 
+	if (FBitSet(m_EFlags, EFLAG_TAUNT))
+	{
+		m_EFlags &= ~EFLAG_TAUNT;
+		m_EFlags |= EFLAG_CANCEL;
+		m_fTauntFullTime = m_fTauntCancelTime = 0;
+	}
+
 	// FIX, this needs to queue them up and delay
 	if (m_pActiveItem && m_pActiveItem->m_pPlayer)
 		m_pActiveItem->Holster( );
@@ -7058,6 +7065,13 @@ BOOL CBasePlayer :: SwitchWeapon( CBasePlayerItem *pWeapon )
 	}
 	
 	ResetAutoaim( );
+
+	if (FBitSet(m_EFlags, EFLAG_TAUNT))
+	{
+		m_EFlags &= ~EFLAG_TAUNT;
+		m_EFlags |= EFLAG_CANCEL;
+		m_fTauntFullTime = m_fTauntCancelTime = 0;
+	}
 	
 	if (m_pActiveItem && m_pActiveItem->m_pPlayer)
 	{

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -1677,11 +1677,17 @@ void CBasePlayer::PlayerDeathThink(void)
 		}
 	}
 
+	if (FBitSet(m_EFlags, EFLAG_TAUNT))
+	{
+		m_EFlags &= ~EFLAG_TAUNT;
+		m_EFlags |= EFLAG_CANCEL;
+	}
+
 	if ( HasWeapons() )
 	{
 		// If we got killed during these events, cancel them
 		m_EFlags &= ~EFLAG_PLAYERKICK & ~EFLAG_SLIDE & ~EFLAG_HURRICANE;
-		m_EFlags &= ~EFLAG_TAUNT & ~EFLAG_FORCEGRAB & ~EFLAG_THROW;
+		m_EFlags &= ~EFLAG_FORCEGRAB & ~EFLAG_THROW;
 
 		// we drop the guns here because weapons that have an area effect and can kill their user
 		// will sometimes crash coming back from CBasePlayer::Killed() if they kill their owner because the

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -7054,6 +7054,53 @@ BOOL CBasePlayer::HasNamedPlayerItem( const char *pszItemName )
 	return FALSE;
 }
 
+BOOL CBasePlayer::GetHeaviestWeapon( CBasePlayerItem *pCurrentWeapon )
+{
+	CBasePlayerItem *pCheck;
+	CBasePlayerItem *pBest = NULL;// this will be used in the event that we don't find a weapon in the same category.
+	int iBestWeight = -1;// no weapon lower than -1 can be autoswitched to
+
+	for ( int i = 0 ; i < MAX_ITEM_TYPES ; i++ )
+	{
+		pCheck = m_rgpPlayerItems[ i ];
+		ALERT(at_aiconsole, "i=%d\n", i);
+
+		while ( pCheck && pCheck->m_pPlayer )
+		{
+			ALERT(at_aiconsole, "pCheck->iWeight()=%d\n", pCheck->iWeight());
+			if ( pCheck->iWeight() > iBestWeight && pCheck != pCurrentWeapon )
+			{
+				ALERT ( at_console, "Considering %s\n", STRING( pCheck->pev->classname ) );
+				// we keep updating the 'best' weapon just in case we can't find a weapon of the same weight
+				// that the player was using. This will end up leaving the player with his heaviest-weighted
+				// weapon.
+				if ( pCheck->CanDeploy() )
+				{
+					ALERT(at_aiconsole, "iBestWeight=%d\n", iBestWeight);
+					// if this weapon is useable, flag it as the best
+					iBestWeight = pCheck->iWeight();
+					pBest = pCheck;
+					ALERT(at_aiconsole, "pBest=%s\n", STRING(pBest->pev->classname));
+				}
+			}
+
+			ALERT(at_aiconsole, "pCheck->m_pNext!\n");
+			pCheck = pCheck->m_pNext;
+		}
+	}
+
+	if ( !pBest )
+	{
+		ALERT(at_aiconsole, "!pBest\n");
+		return FALSE;
+	}
+
+	ALERT(at_aiconsole, "SwitchWeapon(%s)\n", STRING(pBest->pev->classname));
+	SwitchWeapon( pBest );
+
+	return TRUE;
+}
+
 //=========================================================
 // 
 //=========================================================

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -921,11 +921,10 @@ void CBasePlayer::PackDeadPlayerItems( void )
 	{
 		// TODO: bot may have not of had an active item?
 	}
-	else if (iPW == 1 && FStrEq("weapon_fists", STRING(rgpPackWeapons[0]->pev->classname)))
-	{
-		// TODO: do something special if only packed fists
-	}
-	else if (iPW == 1 && FStrEq("weapon_nuke", STRING(rgpPackWeapons[0]->pev->classname)))
+	else if (iPW == 1 && 
+			(FStrEq("weapon_fists", STRING(rgpPackWeapons[0]->pev->classname)) ||
+			FStrEq("weapon_vice", STRING(rgpPackWeapons[0]->pev->classname)) ||
+			FStrEq("weapon_nuke", STRING(rgpPackWeapons[0]->pev->classname))) )
 	{
 		// TODO: do something special if only packed nuke
 	}

--- a/dlls/player.h
+++ b/dlls/player.h
@@ -294,6 +294,8 @@ public:
 	// Prophunt
 	int m_iPropsDeployed;
 
+	BOOL GetHeaviestWeapon( CBasePlayerItem *pCurrentWeapon );
+
 	EHANDLE pHeldItem;
 	BOOL m_iHoldingItem;
 

--- a/dlls/triggers.cpp
+++ b/dlls/triggers.cpp
@@ -1938,7 +1938,7 @@ void CBaseTrigger :: TeleportTouch( CBaseEntity *pOther )
 
 	// Kill?
 	CBaseEntity *ent = NULL;
-	while ( (ent = UTIL_FindEntityInSphere( ent, pevToucher->origin, 128 )) != NULL )
+	while ( (ent = UTIL_FindEntityInSphere( ent, pevToucher->origin, 64 )) != NULL )
 	{
 		// if ent is a client, kill em (unless they are ourselves)
 		if ( ent->IsPlayer() && !(VARS(ent->edict()) == pevToucher) && ent->IsAlive() && !ent->pev->iuser1 )

--- a/dlls/weapons.cpp
+++ b/dlls/weapons.cpp
@@ -1064,14 +1064,12 @@ void CBasePlayerWeapon::ItemPostFrame( void )
 		if ((m_pPlayer->pev->button & IN_ATTACK) &&
 			CanAttack( m_flNextPrimaryAttack, gpGlobals->time, UseDecrement() ))
 		{
-			if (m_pPlayer->pev->fuser4 > 56)
-				m_pPlayer->pev->fuser4 = 1;
+			if (m_pPlayer->pev->fuser4 >= 59) // 52 weapon + 7 ammo
+				m_pPlayer->pev->fuser4 = 0;
 			m_pPlayer->pev->fuser4 += 1;
 			// Skip blank spaces in model
 			if (m_pPlayer->pev->fuser4 == 32)
 				m_pPlayer->pev->fuser4 = 35;
-
-			// ALERT(at_aiconsole, "fuser4 = %.0f\n", m_pPlayer->pev->fuser4);
 
 			m_flNextPrimaryAttack = m_flNextSecondaryAttack =  UTIL_WeaponTimeBase() + 0.25;
 			m_pPlayer->pev->button &= ~IN_ATTACK;
@@ -1081,13 +1079,11 @@ void CBasePlayerWeapon::ItemPostFrame( void )
 				CanAttack( m_flNextSecondaryAttack, gpGlobals->time, UseDecrement() ))
 		{
 			m_pPlayer->pev->fuser4 -= 1;
-			if (m_pPlayer->pev->fuser4 < 1)
-				m_pPlayer->pev->fuser4 = 56;
+			if (m_pPlayer->pev->fuser4 <= 0)
+				m_pPlayer->pev->fuser4 = 59; // 52 weapon + 7 ammo
 			// Skip blank spaces in model
 			if (m_pPlayer->pev->fuser4 == 34)
 				m_pPlayer->pev->fuser4 = 31;
-
-			// ALERT(at_aiconsole, "fuser4 = %.0f\n", m_pPlayer->pev->fuser4);
 
 			m_flNextPrimaryAttack = m_flNextSecondaryAttack =  UTIL_WeaponTimeBase() + 0.25;
 			m_pPlayer->pev->button &= ~IN_ATTACK;

--- a/dlls/weapons.cpp
+++ b/dlls/weapons.cpp
@@ -2408,6 +2408,7 @@ BOOL CWeaponBox::PackWeapon( CBasePlayerItem *pWeapon )
 	else if (pWeapon->m_iId == WEAPON_HANDGRENADE)
 	{
 		SET_MODEL( ENT(pev), "models/w_grenade.mdl");
+		pev->body = 0;
 		pev->sequence = floating;
 	}
 

--- a/dlls/weapons.cpp
+++ b/dlls/weapons.cpp
@@ -1233,9 +1233,9 @@ void CBasePlayerWeapon::ItemPostFrame( void )
 				m_pPlayer->SetAnimation( PLAYER_ATTACK1 );
 				Vector vecFireDir = m_pPlayer->pev->v_angle;
 				UTIL_MakeVectors( vecFireDir );
-				CDisc::CreateDisc( m_pPlayer->pev->origin + (m_pPlayer->pev->view_ofs * 0.25) + gpGlobals->v_forward * 16, vecFireDir, m_pPlayer, FALSE, 0 );
-				CDisc::CreateDisc( m_pPlayer->pev->origin + (m_pPlayer->pev->view_ofs * 0.25) + gpGlobals->v_forward * 16 + gpGlobals->v_right * -24, vecFireDir, m_pPlayer, FALSE, 0 );
-				CDisc::CreateDisc( m_pPlayer->pev->origin + (m_pPlayer->pev->view_ofs * 0.25) + gpGlobals->v_forward * 16 + gpGlobals->v_right * 24, vecFireDir, m_pPlayer, FALSE, 0 );
+				CDisc::CreateDisc( m_pPlayer->pev->origin + m_pPlayer->pev->view_ofs + gpGlobals->v_forward * 16, vecFireDir, m_pPlayer, FALSE, 0 );
+				CDisc::CreateDisc( m_pPlayer->pev->origin + m_pPlayer->pev->view_ofs + gpGlobals->v_forward * 16 + gpGlobals->v_right * -24, vecFireDir, m_pPlayer, FALSE, 0 );
+				CDisc::CreateDisc( m_pPlayer->pev->origin + m_pPlayer->pev->view_ofs + gpGlobals->v_forward * 16 + gpGlobals->v_right * 24, vecFireDir, m_pPlayer, FALSE, 0 );
 				EMIT_SOUND_DYN( m_pPlayer->edict(), CHAN_WEAPON, "weapons/cbar_miss1.wav", 1.0, ATTN_NORM, 0, 98 + RANDOM_LONG(0,3)); 
 
 				m_flNextPrimaryAttack = m_flNextSecondaryAttack =  UTIL_WeaponTimeBase() + 0.5;

--- a/dlls/weapons.cpp
+++ b/dlls/weapons.cpp
@@ -1060,6 +1060,22 @@ BOOL CanAttack( float attack_time, float curtime, BOOL isPredicted )
 
 void CBasePlayerWeapon::ItemPostFrame( void )
 {
+	/*
+	if ((m_fInReload) && ( m_pPlayer->m_flNextAttack <= UTIL_WeaponTimeBase() ) )
+	{
+		if (RANDOM_LONG(0,2) == 1)
+		{
+			PlayEmptySound();
+			ThrowWeapon(TRUE);
+			return;
+		}
+	}
+	*/
+
+	BOOL oktofire = TRUE;
+	if (g_pGameRules->IsCtC() && m_pPlayer->pev->fuser4 > 0)
+		oktofire = FALSE;
+
 	if (g_pGameRules->IsPropHunt() && m_pPlayer->pev->fuser4 > 0) {
 		if ((m_pPlayer->pev->button & IN_ATTACK) &&
 			CanAttack( m_flNextPrimaryAttack, gpGlobals->time, UseDecrement() ))
@@ -1123,7 +1139,7 @@ void CBasePlayerWeapon::ItemPostFrame( void )
 		return;
 	}
 
-	if (g_pGameRules->MutatorEnabled(MUTATOR_DEALTER) ||
+	if ((g_pGameRules->MutatorEnabled(MUTATOR_DEALTER) && oktofire) ||
 		(g_pGameRules->IsShidden() && m_pPlayer->pev->fuser4 > 0)) {
 		if ((m_pPlayer->pev->button & IN_ATTACK) &&
 			CanAttack( m_flNextPrimaryAttack, gpGlobals->time, UseDecrement() ))
@@ -1191,7 +1207,7 @@ void CBasePlayerWeapon::ItemPostFrame( void )
 		return;
 	}
 
-	if (g_pGameRules->MutatorEnabled(MUTATOR_RICOCHET)) {
+	if (g_pGameRules->MutatorEnabled(MUTATOR_RICOCHET) && oktofire) {
 		if ((m_pPlayer->pev->button & IN_ATTACK) &&
 			CanAttack( m_flNextPrimaryAttack, gpGlobals->time, UseDecrement() ))
 		{


### PR DESCRIPTION
## December 2024 Test #1

[x] ctf frag on game end?
[x] prophunt model spin fix?
    [x] fix invisible model index
[x] skeletons should not pick up weapons
    [x] melee only
    [x] remove flames on skeleton in view.
        [x] make sure skeleton icon shows
[x] strip weapons at end of horde
[x] capture the chumtoad - use score
    [x] dont shoot in ctc, only hurt chumtoad dude
    [x] farts can kill other if havign chumtoad
[x] pull skulls out of walls
[x] fix flat grenade model
[x] with auto taunt on, stop taunt on death
[x] smoke on sawed off too much
[x] flamethrower close up fix
[x] ctf score keeps disappearing after spawn?
[x] cancel taunt on weapon change?
[x] Stop coldspot from moving when game is over
[x] fixed disc angle, path, and angles
---
[x] vice during god mutator
[x] improve random vote if deadlocked
[x] improve mutator vote visualization
[x] improve pushy mutator behavior
[x] instant decap on ricochet head hit
[x] auto decap on ricochet hit in head