### PR TITLE
GSS playtest jan 2025 patches

### DIFF
--- a/cl_dll/ev_hldm.cpp
+++ b/cl_dll/ev_hldm.cpp
@@ -4037,16 +4037,13 @@ void EV_FireZapgun( event_args_t *args )
 
 	if ( EV_IsLocal( idx ) )
 	{
-		// Python uses different body in multiplayer versus single player
-		int multiplayer = gEngfuncs.GetMaxClients() == 1 ? 0 : 1;
-
 		// Add muzzle flash to current weapon model
 		EV_MuzzleFlash();
 		gEngfuncs.pEventAPI->EV_WeaponAnimation( ZAPGUN_SHOOT, 0 );
 
-		V_PunchAxis(PITCH, gEngfuncs.pfnRandomFloat(-10.0, -15.0) );
-		V_PunchAxis(YAW, gEngfuncs.pfnRandomFloat(-3.0, -5.0)); //yaw, - = right
-		V_PunchAxis(ROLL, gEngfuncs.pfnRandomFloat(3.0, 5.0)); //roll, - = left
+		//V_PunchAxis(PITCH, gEngfuncs.pfnRandomFloat(-10.0, -15.0) );
+		//V_PunchAxis(YAW, gEngfuncs.pfnRandomFloat(-3.0, -5.0)); //yaw, - = right
+		//V_PunchAxis(ROLL, gEngfuncs.pfnRandomFloat(3.0, 5.0)); //roll, - = left
 	}
 
 	gEngfuncs.pEventAPI->EV_PlaySound( idx, origin, CHAN_WEAPON, "zapgun.wav", gEngfuncs.pfnRandomFloat(0.8, 0.9), ATTN_NORM, 0, PITCH_NORM );

--- a/dlls/arena_gamerules.cpp
+++ b/dlls/arena_gamerules.cpp
@@ -348,7 +348,7 @@ void CHalfLifeArena::Think( void )
 		{
 			CBasePlayer *plr = (CBasePlayer *)UTIL_PlayerByIndex( i );
 
-			if ( plr && plr->IsPlayer() )
+			if ( plr && plr->IsPlayer() && !plr->HasDisconnected )
 			{ 
 				if ( m_iPlayer1 == i || m_iPlayer2 == i )
 				{

--- a/dlls/chilldemic_gamerules.cpp
+++ b/dlls/chilldemic_gamerules.cpp
@@ -607,12 +607,9 @@ BOOL CHalfLifeChilldemic::FPlayerCanRespawn( CBasePlayer *pPlayer )
 
 void CHalfLifeChilldemic::PlayerKilled( CBasePlayer *pVictim, entvars_t *pKiller, entvars_t *pInflictor )
 {
-	pVictim->pev->frags = 0; // clear immediately for winner determination
-
 	CHalfLifeMultiplay::PlayerKilled(pVictim, pKiller, pInflictor);
 
-	int survivors_left = 0;
-	int skeletons_left = 0;
+	int survivors_left = 0, skeletons_left = 0;
 	for (int i = 1; i <= gpGlobals->maxClients; i++) {
 		if (m_iPlayersInArena[i-1] > 0)
 		{
@@ -633,6 +630,7 @@ void CHalfLifeChilldemic::PlayerKilled( CBasePlayer *pVictim, entvars_t *pKiller
 	// Person was survivor
 	if ( pVictim->pev->fuser4 == 0 )
 	{
+		pVictim->pev->frags = 0; // clear immediately for winner determination
 		if (survivors_left >= 1)
 		{
 			UTIL_ClientPrintAll(HUD_PRINTTALK,
@@ -652,9 +650,6 @@ void CHalfLifeChilldemic::PlayerKilled( CBasePlayer *pVictim, entvars_t *pKiller
 
 		g_engfuncs.pfnSetClientKeyValue( ENTINDEX( pVictim->edict() ),
 			g_engfuncs.pfnGetInfoKeyBuffer( pVictim->edict() ), "model", "skeleton" );
-		//g_engfuncs.pfnSetClientKeyValue( ENTINDEX( pVictim->edict() ),
-		//	g_engfuncs.pfnGetInfoKeyBuffer( pVictim->edict() ), "team", "skeleton" );
-		
 		strncpy( pVictim->m_szTeamName, "skeleton", TEAM_NAME_LENGTH );
 	}
 	else
@@ -662,6 +657,7 @@ void CHalfLifeChilldemic::PlayerKilled( CBasePlayer *pVictim, entvars_t *pKiller
 		// Special case, last survivor, dispatched skeletons sent to observer.
 		if (m_iSurvivorsRemain <= 1 && !pVictim->HasDisconnected)
 		{
+			pVictim->pev->frags = 0; // clear immediately for winner determination
 			pVictim->m_flForceToObserverTime = gpGlobals->time + 2.0;
 			MESSAGE_BEGIN( MSG_ONE, gmsgStatusIcon, NULL, pVictim->pev );
 				WRITE_BYTE(0);

--- a/dlls/chilldemic_gamerules.h
+++ b/dlls/chilldemic_gamerules.h
@@ -32,6 +32,7 @@ public:
 	virtual const char *GetTeamID( CBaseEntity *pEntity );
 	virtual BOOL ShouldAutoAim( CBasePlayer *pPlayer, edict_t *target );
 	virtual BOOL IsRoundBased( void );
+	virtual void DetermineWinner( void );
 
 private:
 	int m_iSurvivorsRemain;

--- a/dlls/gungame_gamerules.cpp
+++ b/dlls/gungame_gamerules.cpp
@@ -390,7 +390,7 @@ int CHalfLifeGunGame::IPointsForKill( CBasePlayer *pAttacker, CBasePlayer *pKill
 									WRITE_STRING("GunGame complete");
 									WRITE_STRING("");
 									WRITE_BYTE(0);
-									WRITE_STRING(UTIL_VarArgs("Winner of round %d is %s!\n", m_iSuccessfulRounds+1, STRING(pAttacker->pev->netname)));
+									WRITE_STRING(UTIL_VarArgs("The winner is %s!\n", STRING(pAttacker->pev->netname)));
 								MESSAGE_END();
 							}
 						}

--- a/dlls/horde_gamerules.h
+++ b/dlls/horde_gamerules.h
@@ -36,6 +36,7 @@ public:
 	virtual BOOL IsRoundBased( void );
 	virtual BOOL CanHavePlayerItem( CBasePlayer *pPlayer, CBasePlayerItem *pItem );
 	virtual BOOL CanRandomizeWeapon( const char *name );
+	virtual void DetermineWinner( void );
 
 private:
 	int m_iSurvivorsRemain;

--- a/dlls/jvs_gamerules.cpp
+++ b/dlls/jvs_gamerules.cpp
@@ -455,15 +455,7 @@ void CHalfLifeJesusVsSanta::FPlayerTookDamage( float flDamage, CBasePlayer *pVic
 	if (pKiller && pKiller->IsPlayer())
 	{
 		pPlayerAttacker = (CBasePlayer *)pKiller;
-		if ( pPlayerAttacker != pVictim && pVictim->IsArmoredMan )
-		{
-			pPlayerAttacker->m_fArmoredManHits += flDamage;
-#ifdef _DEBUG
-			ALERT(at_notice, UTIL_VarArgs("Total damage against Jesus is: %.2f\n",
-				pPlayerAttacker->m_fArmoredManHits));
-#endif
-		}
-		else if ( pPlayerAttacker != pVictim && !pPlayerAttacker->IsArmoredMan && !pVictim->IsArmoredMan )
+		if ( pPlayerAttacker != pVictim && !pPlayerAttacker->IsArmoredMan && !pVictim->IsArmoredMan )
 		{
 			ClientPrint(pPlayerAttacker->pev, HUD_PRINTCENTER, "Destroy Jesus!\nNot your teammate!");
 		}
@@ -557,16 +549,6 @@ void CHalfLifeJesusVsSanta::PlayerKilled( CBasePlayer *pVictim, entvars_t *pKill
 				WRITE_BYTE(CLIENT_SOUND_MASSACRE);
 			MESSAGE_END();
 		}
-	}
-	else
-	{
-		CBaseEntity *ktmp = CBaseEntity::Instance( pKiller );
-		CBasePlayer *peKiller = NULL;
-		if ( ktmp && (ktmp->Classify() == CLASS_PLAYER) )
-			peKiller = (CBasePlayer*)ktmp;
-		// Last player to frag jesus is the winner, regardless of dole count
-		if ( pVictim->pev != pKiller && ktmp && ktmp->IsPlayer() )
-			peKiller->m_fArmoredManHits = 9999;
 	}
 }
 

--- a/dlls/jvs_gamerules.cpp
+++ b/dlls/jvs_gamerules.cpp
@@ -33,6 +33,87 @@ extern int gmsgObjective;
 extern int gmsgShowTimer;
 extern int gmsgDEraser;
 
+void CHalfLifeJesusVsSanta::DetermineWinner( void )
+{
+	int highest = 1;
+	BOOL IsEqual = FALSE;
+	CBasePlayer *highballer = NULL;
+
+	for ( int i = 1; i <= gpGlobals->maxClients; i++ )
+	{
+		CBasePlayer *plr = (CBasePlayer *)UTIL_PlayerByIndex( i );
+
+		if ( plr && plr->IsPlayer() && plr->IsInArena )
+		{
+			if ( highest <= plr->pev->frags )
+			{
+				if ( highballer && highest == plr->pev->frags )
+				{
+					IsEqual = TRUE;
+					continue;
+				}
+
+				IsEqual = FALSE;
+				highest = plr->pev->frags;
+				highballer = plr;
+			}
+		}
+	}
+
+	if ( highballer )
+	{
+		if (!IsEqual)
+		{
+			UTIL_ClientPrintAll(HUD_PRINTCENTER,
+				UTIL_VarArgs("%s doled the most frags!\n", STRING(highballer->pev->netname)));
+			MESSAGE_BEGIN(MSG_BROADCAST, gmsgObjective);
+				WRITE_STRING("JVS Completed!");
+				WRITE_STRING(UTIL_VarArgs("%s win!", pArmoredMan && pArmoredMan->IsAlive() ? "Jesus" : "Santas"));
+				WRITE_BYTE(0);
+				WRITE_STRING(UTIL_VarArgs("%s doled the most frags!\n", STRING(highballer->pev->netname)));
+			MESSAGE_END();
+
+			DisplayWinnersGoods( highballer );
+		}
+		else
+		{
+			for ( int i = 1; i <= gpGlobals->maxClients; i++ )
+			{
+				CBasePlayer *plr = (CBasePlayer *)UTIL_PlayerByIndex( i );
+
+				if ( plr && plr->IsPlayer() && plr->IsInArena )
+				{
+					if ( plr->pev->frags == highest)
+					{
+						plr->m_iRoundWins++;
+						plr->Celebrate();
+					}
+				}
+			}
+
+			UTIL_ClientPrintAll(HUD_PRINTCENTER, "Numerous victors!");
+			UTIL_ClientPrintAll(HUD_PRINTTALK, "* Round ends with winners!\n");
+			MESSAGE_BEGIN(MSG_BROADCAST, gmsgObjective);
+				WRITE_STRING("JVS Completed!");
+				WRITE_STRING(UTIL_VarArgs("%s win!", pArmoredMan && pArmoredMan->IsAlive() ? "Jesus" : "Santas"));
+				WRITE_BYTE(0);
+				WRITE_STRING("Numerous victors!");
+			MESSAGE_END();
+		}
+	}
+	else
+	{
+		UTIL_ClientPrintAll(HUD_PRINTCENTER, "Round is over!\nNo one has won!\n");
+		UTIL_ClientPrintAll(HUD_PRINTTALK, "* Round ends with no winners!\n");
+		MESSAGE_BEGIN(MSG_BROADCAST, gmsgObjective);
+			WRITE_STRING("JVS Completed!");
+			WRITE_STRING("");
+			WRITE_BYTE(0);
+			WRITE_STRING("No one has won!");
+		MESSAGE_END();
+	}
+}
+
 void CHalfLifeJesusVsSanta::Think( void )
 {
 	CHalfLifeMultiplay::Think();
@@ -170,16 +251,7 @@ void CHalfLifeJesusVsSanta::Think( void )
 			//armored man is alive.
 			if ( pArmoredMan->IsAlive() && clients_alive == 1 )
 			{
-				UTIL_ClientPrintAll(HUD_PRINTCENTER, UTIL_VarArgs("%s has defeated all Santas!\n", STRING(pArmoredMan->pev->netname) ));
-
-				MESSAGE_BEGIN(MSG_BROADCAST, gmsgObjective);
-					WRITE_STRING("Jesus remains!");
-					WRITE_STRING("");
-					WRITE_BYTE(0);
-					WRITE_STRING(UTIL_VarArgs("Jesus saves in round %d of %d!", m_iSuccessfulRounds+1, (int)roundlimit.value));
-				MESSAGE_END();
-
-				DisplayWinnersGoods( pArmoredMan );
+				DetermineWinner();
 				MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
 					WRITE_BYTE(CLIENT_SOUND_KILLINGMACHINE);
 				MESSAGE_END();
@@ -187,64 +259,15 @@ void CHalfLifeJesusVsSanta::Think( void )
 			//the man has been killed.
 			else if ( !pArmoredMan->IsAlive() )
 			{
-				MESSAGE_BEGIN(MSG_BROADCAST, gmsgObjective);
-					WRITE_STRING("Time to buy presents!");
-					WRITE_STRING("");
-					WRITE_BYTE(0);
-					WRITE_STRING(UTIL_VarArgs("Santas win round %d of %d!", m_iSuccessfulRounds+1, (int)roundlimit.value));
+				DetermineWinner();
+				MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
+					WRITE_BYTE(CLIENT_SOUND_OUTSTANDING);
 				MESSAGE_END();
-
-				//find highest damage amount.
-				float highest = 1;
-				BOOL IsEqual = FALSE;
-				CBasePlayer *highballer = NULL;
-
-				for ( int i = 1; i <= gpGlobals->maxClients; i++ )
-				{
-					CBasePlayer *plr = (CBasePlayer *)UTIL_PlayerByIndex( i );
-
-					if ( plr && plr->IsPlayer() && plr->IsInArena )
-					{
-						if ( highest <= plr->m_fArmoredManHits )
-						{
-							if ( highballer && highest == plr->m_fArmoredManHits )
-							{
-								IsEqual = TRUE;
-								continue;
-							}
-
-							IsEqual = FALSE;
-							highest = plr->m_fArmoredManHits;
-							highballer = plr;
-						}
-					}
-				}
-
-				if ( !IsEqual && highballer )
-				{
-					UTIL_ClientPrintAll(HUD_PRINTCENTER,
-						UTIL_VarArgs("Jesus has been destroyed!\n\n%s doled the most damage!\n",
-						STRING(highballer->pev->netname)));
-					DisplayWinnersGoods( highballer );
-					MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
-						WRITE_BYTE(CLIENT_SOUND_OUTSTANDING);
-					MESSAGE_END();
-				}
-				else
-				{
-					UTIL_ClientPrintAll(HUD_PRINTCENTER, "Jesus has been destroyed!\n");
-					UTIL_ClientPrintAll(HUD_PRINTTALK, "* Round ends in a tie!\n");
-					MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
-						WRITE_BYTE(CLIENT_SOUND_HULIMATING_DEAFEAT);
-					MESSAGE_END();
-				}
-
 			}
 			//everyone died.
 			else
 			{
-				UTIL_ClientPrintAll(HUD_PRINTCENTER, "Everyone has been killed!\n");
-				UTIL_ClientPrintAll(HUD_PRINTTALK, "* No winners in this round!\n");
+				DetermineWinner();
 				MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
 					WRITE_BYTE(CLIENT_SOUND_HULIMATING_DEAFEAT);
 				MESSAGE_END();
@@ -391,63 +414,10 @@ BOOL CHalfLifeJesusVsSanta::HasGameTimerExpired( void )
 	//time is up
 	if ( CHalfLifeMultiplay::HasGameTimerExpired() )
 	{
-		int highest = 1;
-		BOOL IsEqual = FALSE;
-		CBasePlayer *highballer = NULL;
-
-		//find highest damage amount.
-		for ( int i = 1; i <= gpGlobals->maxClients; i++ )
-		{
-			CBasePlayer *plr = (CBasePlayer *)UTIL_PlayerByIndex( i );
-
-			if ( plr && plr->IsPlayer() && plr->IsInArena )
-			{
-				if ( highest <= plr->m_fArmoredManHits )
-				{
-					if ( highballer && highest == plr->m_fArmoredManHits )
-					{
-						IsEqual = TRUE;
-						continue;
-					}
-
-					IsEqual = FALSE;
-					highest = plr->m_fArmoredManHits;
-					highballer = plr;
-				}
-			}
-		}
-
-		if ( !IsEqual && highballer )
-		{
-			UTIL_ClientPrintAll(HUD_PRINTCENTER, 
-				UTIL_VarArgs("Time is up!\n\n%s doled the most damage!\n",
-				STRING(highballer->pev->netname)));
-			MESSAGE_BEGIN(MSG_BROADCAST, gmsgObjective);
-				WRITE_STRING("Time is up!");
-				WRITE_STRING("");
-				WRITE_BYTE(0);
-				WRITE_STRING(UTIL_VarArgs("%s doled the most damage!", STRING(highballer->pev->netname)));
-			MESSAGE_END();
-			DisplayWinnersGoods( highballer );
-
-			MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
-				WRITE_BYTE(CLIENT_SOUND_OUTSTANDING);
-			MESSAGE_END();
-		}
-		else
-		{
-			UTIL_ClientPrintAll(HUD_PRINTCENTER, "Time is up!\nNo one has won!\n");
-			UTIL_ClientPrintAll(HUD_PRINTTALK, "* Round ends in a tie!\n");
-			MESSAGE_BEGIN(MSG_BROADCAST, gmsgObjective);
-				WRITE_STRING("Time is up!");
-				WRITE_STRING("");
-				WRITE_BYTE(0);
-				WRITE_STRING("Round ends in a tie!");
-			MESSAGE_END();
-			MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
-				WRITE_BYTE(CLIENT_SOUND_HULIMATING_DEAFEAT);
-			MESSAGE_END();
-		}
+		DetermineWinner();
+		MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
+			WRITE_BYTE(CLIENT_SOUND_OUTSTANDING);
+		MESSAGE_END();
 
 		g_GameInProgress = FALSE;
 		MESSAGE_BEGIN(MSG_ALL, gmsgShowTimer);
@@ -563,6 +533,8 @@ BOOL CHalfLifeJesusVsSanta::FPlayerCanRespawn( CBasePlayer *pPlayer )
 
 void CHalfLifeJesusVsSanta::PlayerKilled( CBasePlayer *pVictim, entvars_t *pKiller, entvars_t *pInflictor )
 {
+	pVictim->pev->frags = 0; // clear immediately for winner determination
+
 	CHalfLifeMultiplay::PlayerKilled(pVictim, pKiller, pInflictor);
 
 	if ( !pVictim->IsArmoredMan )

--- a/dlls/jvs_gamerules.h
+++ b/dlls/jvs_gamerules.h
@@ -34,6 +34,7 @@ public:
 	virtual const char *GetTeamID( CBaseEntity *pEntity );
 	virtual BOOL ShouldAutoAim( CBasePlayer *pPlayer, edict_t *target );
 	virtual BOOL IsRoundBased( void );
+	virtual void DetermineWinner( void );
 
 private:
 	CBasePlayer *pArmoredMan;

--- a/dlls/multiplay_gamerules.cpp
+++ b/dlls/multiplay_gamerules.cpp
@@ -934,7 +934,6 @@ int CHalfLifeMultiplay::CheckClients( void )
 			plr->IsInArena = FALSE;
 			plr->IsArmoredMan = FALSE;
 			plr->pev->fuser4 = 0;
-			plr->m_fArmoredManHits = 0;
 			plr->m_flForceToObserverTime = 0;
 			m_iPlayersInArena[clients-1] = i;
 		}

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -4899,8 +4899,12 @@ void CBasePlayer::StartSelacoSlide( void )
 				WRITE_BYTE( ACROBATICS_SELACO_SLIDE );
 			MESSAGE_END();
 
-			m_fSelacoZ = VEC_DUCK_HULL_MIN.z + 6;
-			pev->view_ofs[2] = m_fSelacoZ;
+			if (!g_pGameRules->MutatorEnabled(MUTATOR_MINIME))
+			{
+				m_fSelacoZ = VEC_DUCK_HULL_MIN.z + 6;
+				pev->view_ofs[2] = m_fSelacoZ;
+			}
+
 			pev->punchangle.z = 15;
 		}
 	}
@@ -5098,13 +5102,18 @@ void CBasePlayer::EndSelacoSlide( void )
 		pev->fov = m_iFOV = 0;
 		m_fSelacoSliding = m_fSelacoHit = FALSE;
 		m_fOffhandTime = m_fSelacoIncrement = m_fSelacoButtonTime = 0;
-		m_fSelacoZ = VEC_VIEW.z;
 		if (g_pGameRules->MutatorEnabled(MUTATOR_ICE))
 			pev->friction = 0.3;
 		else
 			pev->friction = 1.0;
 		m_fSelacoCount = 0;
-		pev->view_ofs[2] = m_fSelacoZ;
+
+		if (!g_pGameRules->MutatorEnabled(MUTATOR_MINIME))
+		{
+			m_fSelacoZ = VEC_VIEW.z;
+			pev->view_ofs[2] = m_fSelacoZ;
+		}
+
 		m_fSelacoIncrement = gpGlobals->time + 0.2;
 
 		m_EFlags &= ~EFLAG_SLIDE_RETRACT & ~EFLAG_SLIDE;

--- a/dlls/player.h
+++ b/dlls/player.h
@@ -257,7 +257,6 @@ public:
 	void ExitObserver( void );
 	BOOL IsSpectator( void ) { return ( m_afPhysicsFlags & PFLAG_OBSERVER ? TRUE : FALSE ); };
 
-	float m_fArmoredManHits;
 	BOOL IsArmoredMan;
 	float m_fHallelujahTime;
 

--- a/dlls/prophunt_gamerules.cpp
+++ b/dlls/prophunt_gamerules.cpp
@@ -1050,7 +1050,9 @@ void CHalfLifePropHunt::PlayerThink( CBasePlayer *pPlayer )
 	CHalfLifeMultiplay::PlayerThink(pPlayer);
 
 	if (pPlayer->pev->fuser4 > 0)
-	{
+	{	
+		pPlayer->pev->air_finished = gpGlobals->time + 5; // never drown
+
 		if (pPlayer->m_flNextPropSound && pPlayer->m_flNextPropSound < gpGlobals->time)
 		{
 			EMIT_SOUND(ENT(pPlayer->pev), CHAN_VOICE, "sprayer.wav", 1, ATTN_NORM);

--- a/dlls/prophunt_gamerules.cpp
+++ b/dlls/prophunt_gamerules.cpp
@@ -216,6 +216,87 @@ CHalfLifePropHunt::CHalfLifePropHunt()
 	m_iPropsRemain = 0;
 }
 
+void CHalfLifePropHunt::DetermineWinner( void )
+{
+	int highest = -9999;
+	BOOL IsEqual = FALSE;
+	CBasePlayer *highballer = NULL;
+
+	for ( int i = 1; i <= gpGlobals->maxClients; i++ )
+	{
+		CBasePlayer *plr = (CBasePlayer *)UTIL_PlayerByIndex( i );
+
+		if ( plr && plr->IsPlayer() && plr->IsInArena )
+		{
+			if ( highest <= plr->pev->frags )
+			{
+				if ( highballer && highest == plr->pev->frags )
+				{
+					IsEqual = TRUE;
+					continue;
+				}
+
+				IsEqual = FALSE;
+				highest = plr->pev->frags;
+				highballer = plr;
+			}
+		}
+	}
+
+	if ( highballer )
+	{
+		if (!IsEqual)
+		{
+			UTIL_ClientPrintAll(HUD_PRINTCENTER,
+				UTIL_VarArgs("%s doled the most frags!\n", STRING(highballer->pev->netname)));
+			MESSAGE_BEGIN(MSG_BROADCAST, gmsgObjective);
+				WRITE_STRING("Prophunt Completed!");
+				WRITE_STRING(UTIL_VarArgs("%s win!", m_iHuntersRemain ? "Hunters" : "Props"));
+				WRITE_BYTE(0);
+				WRITE_STRING(UTIL_VarArgs("%s doled the most frags!\n", STRING(highballer->pev->netname)));
+			MESSAGE_END();
+
+			DisplayWinnersGoods( highballer );
+		}
+		else
+		{
+			for ( int i = 1; i <= gpGlobals->maxClients; i++ )
+			{
+				CBasePlayer *plr = (CBasePlayer *)UTIL_PlayerByIndex( i );
+
+				if ( plr && plr->IsPlayer() && plr->IsInArena )
+				{
+					if ( plr->pev->frags == highest)
+					{
+						plr->m_iRoundWins++;
+						plr->Celebrate();
+					}
+				}
+			}
+
+			UTIL_ClientPrintAll(HUD_PRINTCENTER, "Numerous victors!");
+			UTIL_ClientPrintAll(HUD_PRINTTALK, "* Round ends with winners!\n");
+			MESSAGE_BEGIN(MSG_BROADCAST, gmsgObjective);
+				WRITE_STRING("Prophunt Completed!");
+				WRITE_STRING(UTIL_VarArgs("%s win!", m_iHuntersRemain ? "Hunters" : "Props"));
+				WRITE_BYTE(0);
+				WRITE_STRING("Numerous victors!");
+			MESSAGE_END();
+		}
+	}
+	else
+	{
+		UTIL_ClientPrintAll(HUD_PRINTCENTER, "Round is over!\nNo one has won!\n");
+		UTIL_ClientPrintAll(HUD_PRINTTALK, "* Round ends with no winners!\n");
+		MESSAGE_BEGIN(MSG_BROADCAST, gmsgObjective);
+			WRITE_STRING("Prophunt Completed!");
+			WRITE_STRING("");
+			WRITE_BYTE(0);
+			WRITE_STRING("No one has won!");
+		MESSAGE_END();
+	}
+}
+
 void CHalfLifePropHunt::Think( void )
 {
 	CHalfLifeMultiplay::Think();
@@ -420,111 +501,24 @@ void CHalfLifePropHunt::Think( void )
 			//everyone died.
 			if ( hunters_left <= 0 && props_left <= 0 )
 			{
-				UTIL_ClientPrintAll(HUD_PRINTCENTER, "Everyone has been killed!\n");
-				UTIL_ClientPrintAll(HUD_PRINTTALK, "* No winners in this round!\n");
-				MESSAGE_BEGIN(MSG_BROADCAST, gmsgObjective);
-					WRITE_STRING("Everyone died!");
-					WRITE_STRING("");
-					WRITE_BYTE(0);
-					WRITE_STRING("No winners in this round!");
-				MESSAGE_END();
+				DetermineWinner();
 				MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
 					WRITE_BYTE(CLIENT_SOUND_HULIMATING_DEAFEAT);
 				MESSAGE_END();
 			}
 			else if ( hunters_left <= 0 )
 			{
-				//find highest frag amount.
-				float highest = 1;
-				BOOL IsEqual = FALSE;
-				CBasePlayer *highballer = NULL;
-
-				for ( int i = 1; i <= gpGlobals->maxClients; i++ )
-				{
-					CBasePlayer *plr = (CBasePlayer *)UTIL_PlayerByIndex( i );
-
-					if ( plr && plr->IsPlayer() && plr->IsInArena && plr->pev->fuser4 > 0 )
-					{
-						if ( highest <= plr->pev->frags )
-						{
-							if ( highballer && highest == plr->pev->frags )
-							{
-								IsEqual = TRUE;
-								continue;
-							}
-
-							IsEqual = FALSE;
-							highest = plr->pev->frags;
-							highballer = plr;
-						}
-					}
-				}
-
-				if ( !IsEqual && highballer )
-				{
-					UTIL_ClientPrintAll(HUD_PRINTCENTER,
-						UTIL_VarArgs("Hunters have been defeated!\n\n%s doled the most hit decoys!\n",
-						STRING(highballer->pev->netname)));
-					DisplayWinnersGoods( highballer );
-					MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
-						WRITE_BYTE(CLIENT_SOUND_OUTSTANDING);
-					MESSAGE_END();
-				}
-				else
-				{
-					UTIL_ClientPrintAll(HUD_PRINTCENTER, "Hunters have been defeated!\n");
-					UTIL_ClientPrintAll(HUD_PRINTTALK, "* Round ends in a tie!\n");
-					MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
-						WRITE_BYTE(CLIENT_SOUND_HULIMATING_DEAFEAT);
-					MESSAGE_END();
-				}
+				DetermineWinner();
+				MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
+					WRITE_BYTE(CLIENT_SOUND_OUTSTANDING);
+				MESSAGE_END();
 			}
 			else if ( props_left <= 0 )
 			{
-				//find highest frag amount.
-				float highest = 1;
-				BOOL IsEqual = FALSE;
-				CBasePlayer *highballer = NULL;
-
-				for ( int i = 1; i <= gpGlobals->maxClients; i++ )
-				{
-					CBasePlayer *plr = (CBasePlayer *)UTIL_PlayerByIndex( i );
-
-					if ( plr && plr->IsPlayer() && plr->IsInArena && plr->pev->fuser4 == 0 )
-					{
-						if ( highest <= plr->pev->frags )
-						{
-							if ( highballer && highest == plr->pev->frags )
-							{
-								IsEqual = TRUE;
-								continue;
-							}
-
-							IsEqual = FALSE;
-							highest = plr->pev->frags;
-							highballer = plr;
-						}
-					}
-				}
-
-				if ( !IsEqual && highballer )
-				{
-					UTIL_ClientPrintAll(HUD_PRINTCENTER,
-						UTIL_VarArgs("Props have been defeated!\n\n%s removed the most props!\n",
-						STRING(highballer->pev->netname)));
-					DisplayWinnersGoods( highballer );
-					MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
-						WRITE_BYTE(CLIENT_SOUND_OUTSTANDING);
-					MESSAGE_END();
-				}
-				else
-				{
-					UTIL_ClientPrintAll(HUD_PRINTCENTER, "Props have been defeated!\n");
-					UTIL_ClientPrintAll(HUD_PRINTTALK, "* Round ends in a tie!\n");
-					MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
-						WRITE_BYTE(CLIENT_SOUND_HULIMATING_DEAFEAT);
-					MESSAGE_END();
-				}
+				DetermineWinner();
+				MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
+					WRITE_BYTE(CLIENT_SOUND_OUTSTANDING);
+				MESSAGE_END();
 			}
 
 			m_iSuccessfulRounds++;
@@ -704,63 +698,10 @@ BOOL CHalfLifePropHunt::HasGameTimerExpired( void )
 {
 	if ( CHalfLifeMultiplay::HasGameTimerExpired() )
 	{
-		int highest = -9999; // any frag amount wins.
-		BOOL IsEqual = FALSE;
-		CBasePlayer *highballer = NULL;
-
-		//find highest prop damage amount.
-		for ( int i = 1; i <= gpGlobals->maxClients; i++ )
-		{
-			CBasePlayer *plr = (CBasePlayer *)UTIL_PlayerByIndex( i );
-
-			if ( plr && plr->IsPlayer() && plr->IsInArena && plr->pev->fuser4 > 0)
-			{
-				if ( highest <= plr->pev->frags )
-				{
-					if ( highballer && highest == plr->pev->frags )
-					{
-						IsEqual = TRUE;
-						continue;
-					}
-
-					IsEqual = FALSE;
-					highest = plr->pev->frags;
-					highballer = plr;
-				}
-			}
-		}
-
-		if ( !IsEqual && highballer )
-		{
-			UTIL_ClientPrintAll(HUD_PRINTCENTER, 
-				UTIL_VarArgs("Time is up!\n\n%s doled the most points!\n",
-				STRING(highballer->pev->netname)));
-			MESSAGE_BEGIN(MSG_BROADCAST, gmsgObjective);
-				WRITE_STRING("Time is up!");
-				WRITE_STRING("");
-				WRITE_BYTE(0);
-				WRITE_STRING(UTIL_VarArgs("%s doled the most points!\n", STRING(highballer->pev->netname)));
-			MESSAGE_END();
-			DisplayWinnersGoods( highballer );
-
-			MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
-				WRITE_BYTE(CLIENT_SOUND_OUTSTANDING);
-			MESSAGE_END();
-		}
-		else
-		{
-			UTIL_ClientPrintAll(HUD_PRINTCENTER, "Time is up!\nNo one has won!\n");
-			UTIL_ClientPrintAll(HUD_PRINTTALK, "* Round ends in a tie!\n");
-			MESSAGE_BEGIN(MSG_BROADCAST, gmsgObjective);
-				WRITE_STRING("Time is up!");
-				WRITE_STRING("");
-				WRITE_BYTE(0);
-				WRITE_STRING("No one has won!");
-			MESSAGE_END();
-			MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
-				WRITE_BYTE(CLIENT_SOUND_HULIMATING_DEAFEAT);
-			MESSAGE_END();
-		}
+		DetermineWinner();
+		MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
+			WRITE_BYTE(CLIENT_SOUND_OUTSTANDING);
+		MESSAGE_END();
 
 		g_GameInProgress = FALSE;
 		MESSAGE_BEGIN(MSG_ALL, gmsgShowTimer);
@@ -1102,4 +1043,11 @@ BOOL CHalfLifePropHunt::MutatorAllowed(const char *mutator)
 		return FALSE;
 
 	return CHalfLifeMultiplay::MutatorAllowed(mutator);
+}
+
+void CHalfLifePropHunt::PlayerKilled( CBasePlayer *pVictim, entvars_t *pKiller, entvars_t *pInflictor )
+{
+	pVictim->pev->frags = 0; // clear immediately for winner determination
+
+	CHalfLifeMultiplay::PlayerKilled(pVictim, pKiller, pInflictor);
 }

--- a/dlls/prophunt_gamerules.h
+++ b/dlls/prophunt_gamerules.h
@@ -40,6 +40,8 @@ public:
 	virtual BOOL IsRoundBased( void );
 	virtual BOOL FPlayerCanRespawn( CBasePlayer *pPlayer );
 	virtual BOOL MutatorAllowed(const char *mutator);
+	virtual void DetermineWinner( void );
+	virtual void PlayerKilled( CBasePlayer *pVictim, entvars_t *pKiller, entvars_t *pInflictor );
 
 private:
 	int m_iHuntersRemain;

--- a/dlls/shidden_gamerules.cpp
+++ b/dlls/shidden_gamerules.cpp
@@ -37,6 +37,87 @@ CHalfLifeShidden::CHalfLifeShidden()
 	m_iDealtersRemain = 0;
 }
 
+void CHalfLifeShidden::DetermineWinner( void )
+{
+	int highest = 1;
+	BOOL IsEqual = FALSE;
+	CBasePlayer *highballer = NULL;
+
+	for ( int i = 1; i <= gpGlobals->maxClients; i++ )
+	{
+		CBasePlayer *plr = (CBasePlayer *)UTIL_PlayerByIndex( i );
+
+		if ( plr && plr->IsPlayer() && plr->IsInArena )
+		{
+			if ( highest <= plr->pev->frags )
+			{
+				if ( highballer && highest == plr->pev->frags )
+				{
+					IsEqual = TRUE;
+					continue;
+				}
+
+				IsEqual = FALSE;
+				highest = plr->pev->frags;
+				highballer = plr;
+			}
+		}
+	}
+
+	if ( highballer )
+	{
+		if (!IsEqual)
+		{
+			UTIL_ClientPrintAll(HUD_PRINTCENTER,
+				UTIL_VarArgs("%s doled the most frags!\n", STRING(highballer->pev->netname)));
+			MESSAGE_BEGIN(MSG_BROADCAST, gmsgObjective);
+				WRITE_STRING("Shidden Completed!");
+				WRITE_STRING(UTIL_VarArgs("%s win!", m_iDealtersRemain ? "Dealters" : "Smelters"));
+				WRITE_BYTE(0);
+				WRITE_STRING(UTIL_VarArgs("%s doled the most frags!\n", STRING(highballer->pev->netname)));
+			MESSAGE_END();
+
+			DisplayWinnersGoods( highballer );
+		}
+		else
+		{
+			for ( int i = 1; i <= gpGlobals->maxClients; i++ )
+			{
+				CBasePlayer *plr = (CBasePlayer *)UTIL_PlayerByIndex( i );
+
+				if ( plr && plr->IsPlayer() && plr->IsInArena )
+				{
+					if ( plr->pev->frags == highest)
+					{
+						plr->m_iRoundWins++;
+						plr->Celebrate();
+					}
+				}
+			}
+
+			UTIL_ClientPrintAll(HUD_PRINTCENTER, "Numerous victors!");
+			UTIL_ClientPrintAll(HUD_PRINTTALK, "* Round ends with winners!\n");
+			MESSAGE_BEGIN(MSG_BROADCAST, gmsgObjective);
+				WRITE_STRING("Shidden Completed!");
+				WRITE_STRING(UTIL_VarArgs("%s win!", m_iDealtersRemain ? "Dealters" : "Smelters"));
+				WRITE_BYTE(0);
+				WRITE_STRING("Numerous victors!");
+			MESSAGE_END();
+		}
+	}
+	else
+	{
+		UTIL_ClientPrintAll(HUD_PRINTCENTER, "Round is over!\nNo one has won!\n");
+		UTIL_ClientPrintAll(HUD_PRINTTALK, "* Round ends with no winners!\n");
+		MESSAGE_BEGIN(MSG_BROADCAST, gmsgObjective);
+			WRITE_STRING("Shidden Completed!");
+			WRITE_STRING("");
+			WRITE_BYTE(0);
+			WRITE_STRING("No one has won!");
+		MESSAGE_END();
+	}
+}
+
 void CHalfLifeShidden::Think( void )
 {
 	CHalfLifeMultiplay::Think();
@@ -262,14 +343,7 @@ void CHalfLifeShidden::Think( void )
 			//everyone died.
 			if ( smelters_left <= 0 && dealters_left <= 0 )
 			{
-				UTIL_ClientPrintAll(HUD_PRINTCENTER, "Everyone has been killed!\n");
-				UTIL_ClientPrintAll(HUD_PRINTTALK, "* No winners in this round!\n");
-				MESSAGE_BEGIN(MSG_BROADCAST, gmsgObjective);
-					WRITE_STRING("Everyone died!");
-					WRITE_STRING("");
-					WRITE_BYTE(0);
-					WRITE_STRING("No winners in this round!");
-				MESSAGE_END();
+				DetermineWinner();
 				MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
 					WRITE_BYTE(CLIENT_SOUND_HULIMATING_DEAFEAT);
 				MESSAGE_END();
@@ -277,98 +351,18 @@ void CHalfLifeShidden::Think( void )
 			//smelters all dead
 			else if ( smelters_left <= 0 )
 			{
-				//find highest frag amount.
-				float highest = 1;
-				BOOL IsEqual = FALSE;
-				CBasePlayer *highballer = NULL;
-
-				for ( int i = 1; i <= gpGlobals->maxClients; i++ )
-				{
-					CBasePlayer *plr = (CBasePlayer *)UTIL_PlayerByIndex( i );
-
-					if ( plr && plr->IsPlayer() && plr->IsInArena && plr->pev->fuser4 > 0 )
-					{
-						if ( highest <= plr->pev->frags )
-						{
-							if ( highballer && highest == plr->pev->frags )
-							{
-								IsEqual = TRUE;
-								continue;
-							}
-
-							IsEqual = FALSE;
-							highest = plr->pev->frags;
-							highballer = plr;
-						}
-					}
-				}
-
-				if ( !IsEqual && highballer )
-				{
-					UTIL_ClientPrintAll(HUD_PRINTCENTER,
-						UTIL_VarArgs("Smelters have been defeated!\n\n%s doled the most gas!\n",
-						STRING(highballer->pev->netname)));
-					DisplayWinnersGoods( highballer );
-					MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
-						WRITE_BYTE(CLIENT_SOUND_OUTSTANDING);
-					MESSAGE_END();
-				}
-				else
-				{
-					UTIL_ClientPrintAll(HUD_PRINTCENTER, "Smelters have been defeated!\n");
-					UTIL_ClientPrintAll(HUD_PRINTTALK, "* Round ends in a tie!\n");
-					MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
-						WRITE_BYTE(CLIENT_SOUND_HULIMATING_DEAFEAT);
-					MESSAGE_END();
-				}
+				DetermineWinner();
+				MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
+					WRITE_BYTE(CLIENT_SOUND_OUTSTANDING);
+				MESSAGE_END();
 			}
 			//dealters defeated.
 			else if ( dealters_left <= 0 )
 			{
-				//find highest frag amount.
-				float highest = 1;
-				BOOL IsEqual = FALSE;
-				CBasePlayer *highballer = NULL;
-
-				for ( int i = 1; i <= gpGlobals->maxClients; i++ )
-				{
-					CBasePlayer *plr = (CBasePlayer *)UTIL_PlayerByIndex( i );
-
-					if ( plr && plr->IsPlayer() && plr->IsInArena && plr->pev->fuser4 == 0 )
-					{
-						if ( highest <= plr->pev->frags )
-						{
-							if ( highballer && highest == plr->pev->frags )
-							{
-								IsEqual = TRUE;
-								continue;
-							}
-
-							IsEqual = FALSE;
-							highest = plr->pev->frags;
-							highballer = plr;
-						}
-					}
-				}
-
-				if ( !IsEqual && highballer )
-				{
-					UTIL_ClientPrintAll(HUD_PRINTCENTER,
-						UTIL_VarArgs("Dealters have been defeated!\n\n%s doled the most Lysol!\n",
-						STRING(highballer->pev->netname)));
-					DisplayWinnersGoods( highballer );
-					MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
-						WRITE_BYTE(CLIENT_SOUND_OUTSTANDING);
-					MESSAGE_END();
-				}
-				else
-				{
-					UTIL_ClientPrintAll(HUD_PRINTCENTER, "Dealters have been defeated!\n");
-					UTIL_ClientPrintAll(HUD_PRINTTALK, "* Round ends in a tie!\n");
-					MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
-						WRITE_BYTE(CLIENT_SOUND_HULIMATING_DEAFEAT);
-					MESSAGE_END();
-				}
+				DetermineWinner();
+				MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
+					WRITE_BYTE(CLIENT_SOUND_OUTSTANDING);
+				MESSAGE_END();
 			}
 
 			m_iSuccessfulRounds++;
@@ -598,63 +592,10 @@ BOOL CHalfLifeShidden::HasGameTimerExpired( void )
 	//time is up
 	if ( CHalfLifeMultiplay::HasGameTimerExpired() )
 	{
-		int highest = 1;
-		BOOL IsEqual = FALSE;
-		CBasePlayer *highballer = NULL;
-
-		//find highest damage amount.
-		for ( int i = 1; i <= gpGlobals->maxClients; i++ )
-		{
-			CBasePlayer *plr = (CBasePlayer *)UTIL_PlayerByIndex( i );
-
-			if ( plr && plr->IsPlayer() && plr->IsInArena && plr->pev->fuser4 == 0)
-			{
-				if ( highest <= plr->pev->frags )
-				{
-					if ( highballer && highest == plr->pev->frags )
-					{
-						IsEqual = TRUE;
-						continue;
-					}
-
-					IsEqual = FALSE;
-					highest = plr->pev->frags;
-					highballer = plr;
-				}
-			}
-		}
-
-		if ( !IsEqual && highballer )
-		{
-			UTIL_ClientPrintAll(HUD_PRINTCENTER, 
-				UTIL_VarArgs("Time is up!\n\n%s doled the most frags!\n",
-				STRING(highballer->pev->netname)));
-			MESSAGE_BEGIN(MSG_BROADCAST, gmsgObjective);
-				WRITE_STRING("Time is up!");
-				WRITE_STRING("");
-				WRITE_BYTE(0);
-				WRITE_STRING(UTIL_VarArgs("%s doled the most frags!\n", STRING(highballer->pev->netname)));
-			MESSAGE_END();
-			DisplayWinnersGoods( highballer );
-
-			MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
-				WRITE_BYTE(CLIENT_SOUND_OUTSTANDING);
-			MESSAGE_END();
-		}
-		else
-		{
-			UTIL_ClientPrintAll(HUD_PRINTCENTER, "Time is up!\nNo one has won!\n");
-			UTIL_ClientPrintAll(HUD_PRINTTALK, "* Round ends in a tie!\n");
-			MESSAGE_BEGIN(MSG_BROADCAST, gmsgObjective);
-				WRITE_STRING("Time is up!");
-				WRITE_STRING("");
-				WRITE_BYTE(0);
-				WRITE_STRING("No one has won!");
-			MESSAGE_END();
-			MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
-				WRITE_BYTE(CLIENT_SOUND_HULIMATING_DEAFEAT);
-			MESSAGE_END();
-		}
+		DetermineWinner();
+		MESSAGE_BEGIN( MSG_BROADCAST, gmsgPlayClientSound );
+			WRITE_BYTE(CLIENT_SOUND_OUTSTANDING);
+		MESSAGE_END();
 
 		g_GameInProgress = FALSE;
 		MESSAGE_BEGIN(MSG_ALL, gmsgShowTimer);
@@ -709,6 +650,8 @@ BOOL CHalfLifeShidden::FPlayerCanRespawn( CBasePlayer *pPlayer )
 
 void CHalfLifeShidden::PlayerKilled( CBasePlayer *pVictim, entvars_t *pKiller, entvars_t *pInflictor )
 {
+	pVictim->pev->frags = 0; // clear immediately for winner determination
+
 	CHalfLifeMultiplay::PlayerKilled(pVictim, pKiller, pInflictor);
 
 	int smelters_left = 0;

--- a/dlls/shidden_gamerules.h
+++ b/dlls/shidden_gamerules.h
@@ -35,6 +35,7 @@ public:
 	virtual BOOL ShouldAutoAim( CBasePlayer *pPlayer, edict_t *target );
 	virtual BOOL MutatorAllowed(const char *mutator);
 	virtual BOOL IsRoundBased( void );
+	virtual void DetermineWinner( void );
 
 private:
 	int m_iSmeltersRemain;


### PR DESCRIPTION
Improves or patches issues experienced during the Jan 2025 playtest of Beta 5

- Remove zapgun punch angles
- Patch game crash when bot is kicked from the server during arena
- Fix gungame winner printout
- Do not duck in minime mode during selaco slide
- Never drown as a prop
- Normalize determine winner calculations, and include tie wins
- Remove difficult to understand jvs damage rule