### PR TITLE
More GSS playtest jan 2025 patches

### DIFF
--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -967,29 +967,41 @@ int CHudAmmo::Draw(float flTime)
 			SPR_DrawAdditive(0, (ScreenWidth / 2) - 32, (ScreenHeight / 2) - 32, &gHUD.GetSpriteRect(gHUD.GetSpriteIndex("dontshoot")));
 		}
 
+		int w = 0, h = 0, total = (ScreenHeight / 2);
+
 		if (MutatorEnabled(MUTATOR_FASTWEAPONS))
 		{
-			int w = 0, h = 0;
 			GetConsoleStringSize("Fast weapons", &w, &h);
-			DrawConsoleString(ScreenWidth / 2 - (w / 2), (ScreenHeight / 2) + (h * 2), "Fast weapons");
+			total += h;
+			DrawConsoleString(ScreenWidth / 2 - (w / 2), total, "Fast weapons");
 		}
-		else if (MutatorEnabled(MUTATOR_SLOWWEAPONS))
+		
+		if (MutatorEnabled(MUTATOR_SLOWWEAPONS))
 		{
-			int w = 0, h = 0;
 			GetConsoleStringSize("Slow weapons", &w, &h);
-			DrawConsoleString(ScreenWidth / 2 - (w / 2), (ScreenHeight / 2) + (h * 2), "Slow weapons");
+			total += h;
+			DrawConsoleString(ScreenWidth / 2 - (w / 2), total, "Slow weapons");
 		}
-		else if (MutatorEnabled(MUTATOR_DEALTER))
+		
+		if (MutatorEnabled(MUTATOR_DEALTER))
 		{
-			int w = 0, h = 0;
 			GetConsoleStringSize("Farts!", &w, &h);
-			DrawConsoleString(ScreenWidth / 2 - (w / 2), (ScreenHeight / 2) + (h * 2), "Farts!");
+			total += h;
+			DrawConsoleString(ScreenWidth / 2 - (w / 2), total, "Farts!");
 		}
-		else if (MutatorEnabled(MUTATOR_NORELOAD))
+		
+		if (MutatorEnabled(MUTATOR_NORELOAD))
 		{
-			int w = 0, h = 0;
 			GetConsoleStringSize("No reload", &w, &h);
-			DrawConsoleString(ScreenWidth / 2 - (w / 2), (ScreenHeight / 2) + (h * 2), "Slow weapons");
+			total += h;
+			DrawConsoleString(ScreenWidth / 2 - (w / 2), total, "No reload");
+		}
+		
+		if (MutatorEnabled(MUTATOR_RICOCHET))
+		{
+			GetConsoleStringSize("Ricochet", &w, &h);
+			total += h;
+			DrawConsoleString(ScreenWidth / 2 - (w / 2), total, "Ricochet");
 		}
 	}
 

--- a/cl_dll/scoreboard.cpp
+++ b/cl_dll/scoreboard.cpp
@@ -153,8 +153,6 @@ int CHudScoreboard :: Draw( float fTime )
 
 	if (gHUD.m_Teamplay == GAME_LMS)
 		gHUD.DrawHudStringReverse( KILLS_RANGE_MAX + xpos_rel, ypos, 0, "Lives", r, g, b );
-	else if (gHUD.m_Teamplay == GAME_GUNGAME)
-		gHUD.DrawHudStringReverse( KILLS_RANGE_MAX + xpos_rel, ypos, 0, "Level", r, g, b );
 	else if (gHUD.m_Teamplay == GAME_PROPHUNT)
 		gHUD.DrawHudStringReverse( KILLS_RANGE_MAX + xpos_rel, ypos, 0, "Points", r, g, b );
 	else if (gHUD.m_Teamplay == GAME_COLDSKULL)
@@ -164,7 +162,12 @@ int CHudScoreboard :: Draw( float fTime )
 	gHUD.DrawHudString( DIVIDER_POS + xpos_rel, ypos, ScreenWidth, "/", r, g, b );
 	gHUD.DrawHudString( DEATHS_RANGE_MIN + xpos_rel + 5, ypos, ScreenWidth, "Deaths", r, g, b );
 	if (ScoreBased())
-		gHUD.DrawHudString( SCORE_RANGE_MIN + xpos_rel + 5, ypos, ScreenWidth, "Score", r, g, b );
+	{
+		if (gHUD.m_Teamplay != GAME_GUNGAME)
+			gHUD.DrawHudString( SCORE_RANGE_MIN + xpos_rel + 5, ypos, ScreenWidth, "Score", r, g, b );
+		else
+			gHUD.DrawHudString( SCORE_RANGE_MIN + xpos_rel + 5, ypos, ScreenWidth, "Level", r, g, b );
+	}
 	gHUD.DrawHudString( PING_RANGE_MAX + xpos_rel - 35, ypos, ScreenWidth, "Latency", r, g, b );
 
 	if ( can_show_packetloss )

--- a/cl_dll/util.cpp
+++ b/cl_dll/util.cpp
@@ -171,7 +171,8 @@ bool ScoreBased( void )
 			gHUD.m_Teamplay == GAME_HORDE ||
 			gHUD.m_Teamplay == GAME_ICEMAN ||
 			gHUD.m_Teamplay == GAME_PROPHUNT ||
-			gHUD.m_Teamplay == GAME_SHIDDEN);
+			gHUD.m_Teamplay == GAME_SHIDDEN ||
+			gHUD.m_Teamplay == GAME_GUNGAME);
 }
 
 bool SortByWins( void )
@@ -179,5 +180,6 @@ bool SortByWins( void )
 	return (gHUD.m_Teamplay == GAME_BUSTERS ||
 			gHUD.m_Teamplay == GAME_COLDSPOT ||
 			gHUD.m_Teamplay == GAME_CTC ||
-			gHUD.m_Teamplay == GAME_CTF);
+			gHUD.m_Teamplay == GAME_CTF ||
+			gHUD.m_Teamplay == GAME_GUNGAME);
 }

--- a/dlls/ctc_gamerules.h
+++ b/dlls/ctc_gamerules.h
@@ -42,6 +42,7 @@ public:
 	virtual const char *GetTeamID( CBaseEntity *pEntity );
 	virtual BOOL ShouldAutoAim( CBasePlayer *pPlayer, edict_t *target );
 	virtual BOOL MutatorAllowed(const char *mutator);
+	virtual int GetTeamIndex( const char *pTeamName );
 
 private:
 	BOOL m_fChumtoadInPlay;

--- a/dlls/gungame_gamerules.cpp
+++ b/dlls/gungame_gamerules.cpp
@@ -364,25 +364,6 @@ int CHalfLifeGunGame::IPointsForKill( CBasePlayer *pAttacker, CBasePlayer *pKill
 
 							if ( plr && plr->IsPlayer() && !plr->HasDisconnected )
 							{
-								if (ggstartlevel.value > 0 && ggstartlevel.value < MAXLEVEL)
-								{
-									plr->pev->fuser4 = ggstartlevel.value;
-									plr->pev->frags = g_iFrags[(int)ggstartlevel.value - 1];
-								}
-								else
-								{
-									plr->pev->frags = plr->pev->fuser4 = 0;
-								}
-
-								MESSAGE_BEGIN( MSG_ALL, gmsgScoreInfo );
-									WRITE_BYTE( ENTINDEX(plr->edict()) );
-									WRITE_SHORT( plr->pev->frags );
-									WRITE_SHORT( plr->m_iDeaths = 0 );
-									WRITE_SHORT( 0 );
-									WRITE_SHORT( 0 );
-								MESSAGE_END();
-								plr->m_iAssists = 0;
-
 								if (plr->IsAlive())
 									plr->RemoveAllItems(FALSE);
 
@@ -397,8 +378,7 @@ int CHalfLifeGunGame::IPointsForKill( CBasePlayer *pAttacker, CBasePlayer *pKill
 
 						m_fRefreshStats = -1;
 
-						// No frags awarded when round is complete
-						return 0;
+						return 1;
 					}
 					else
 					{
@@ -458,7 +438,11 @@ void CHalfLifeGunGame::PlayerSpawn( CBasePlayer *pPlayer )
 			WRITE_SHORT( 0 );
 		MESSAGE_END();
 	}
-	
+
+	// Game is over, do not give further items
+	if (m_iTopLevel >= MAXLEVEL)
+		return;
+
 	int currentLevel = (int)pPlayer->pev->fuser4;
 	char weapon[32];
 	sprintf(weapon, "%s%s", "weapon_", g_WeaponId[currentLevel]);

--- a/dlls/multiplay_gamerules.cpp
+++ b/dlls/multiplay_gamerules.cpp
@@ -1441,7 +1441,7 @@ void CHalfLifeMultiplay :: InitHUD( CBasePlayer *pl )
 				WRITE_BYTE( i );	// client number
 				WRITE_SHORT( plr->pev->frags );
 				WRITE_SHORT( plr->m_iDeaths );
-				WRITE_SHORT( plr->m_iRoundWins );
+				WRITE_SHORT( g_GameMode != GAME_GUNGAME ? plr->m_iRoundWins : plr->m_iRoundWins + 1 );
 				WRITE_SHORT( GetTeamIndex( plr->m_szTeamName ) + 1 );
 			MESSAGE_END();
 		}

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -2368,7 +2368,7 @@ void CBasePlayer::Jump()
 			EMIT_SOUND(ENT(pev), CHAN_VOICE, "player/pl_step1.wav", 1, ATTN_NORM);
 
 		if (pev->velocity.Length2D() > 100 && m_iJumpCount == 3)
-			StartFrontFlip(TRUE);
+			StartFrontFlip();
 
 		return;
 	}
@@ -4793,7 +4793,7 @@ void CBasePlayer::ImpulseCommands( )
 		StartBackFlip();
 		break;
 	case 213:
-		StartFrontFlip(TRUE);
+		StartFrontFlip();
 		break;
 	case 214:
 		StartHurricaneKick();
@@ -5225,7 +5225,7 @@ void CBasePlayer::StartBackFlip( void )
 	}
 }
 
-void CBasePlayer::StartFrontFlip( BOOL addVelocity )
+void CBasePlayer::StartFrontFlip( void )
 {
 	if (!acrobatics.value)
 		return;
@@ -5238,16 +5238,17 @@ void CBasePlayer::StartFrontFlip( BOOL addVelocity )
 		return;
 
 	if (m_fFlipTime < gpGlobals->time) {
-		if (addVelocity)
+		// direct tap or if completing a triple jump
+		if (FBitSet(pev->flags, FL_ONGROUND) || m_iJumpCount == 3)
 		{
 			UTIL_MakeVectors(pev->angles);
 			pev->velocity = (gpGlobals->v_forward * 300) + (gpGlobals->v_up * 400);
+			SetAnimation( PLAYER_FRONT_FLIP );
+			MESSAGE_BEGIN( MSG_ONE, gmsgAcrobatics, NULL, pev );
+				WRITE_BYTE( ACROBATICS_FLIP_FRONT );
+			MESSAGE_END();
 		}
 		m_fFlipTime = gpGlobals->time + 0.75;
-		SetAnimation( PLAYER_FRONT_FLIP );
-		MESSAGE_BEGIN( MSG_ONE, gmsgAcrobatics, NULL, pev );
-			WRITE_BYTE( ACROBATICS_FLIP_FRONT );
-		MESSAGE_END();
 	}
 }
 

--- a/dlls/player.h
+++ b/dlls/player.h
@@ -264,7 +264,7 @@ public:
 	void StartRightFlip( void );
 	void StartLeftFlip( void );
 	void StartBackFlip( void );
-	void StartFrontFlip( BOOL addVelocity );
+	void StartFrontFlip( void );
 	void StartHurricaneKick( void );
 	void EndHurricaneKick( void );
 	void TraceHitOfFlip( void );

--- a/dlls/prophunt_gamerules.cpp
+++ b/dlls/prophunt_gamerules.cpp
@@ -1051,3 +1051,23 @@ void CHalfLifePropHunt::PlayerKilled( CBasePlayer *pVictim, entvars_t *pKiller, 
 
 	CHalfLifeMultiplay::PlayerKilled(pVictim, pKiller, pInflictor);
 }
+
+BOOL CHalfLifePropHunt::AllowRuneSpawn( const char *szRune )
+{
+	return FALSE;
+}
+
+int CHalfLifePropHunt::WeaponShouldRespawn( CBasePlayerItem *pWeapon )
+{
+	return GR_WEAPON_RESPAWN_NO;
+}
+
+int CHalfLifePropHunt::ItemShouldRespawn( CItem *pItem )
+{
+	return GR_ITEM_RESPAWN_NO;
+}
+
+int CHalfLifePropHunt::AmmoShouldRespawn( CBasePlayerAmmo *pAmmo )
+{
+	return GR_AMMO_RESPAWN_NO;
+}

--- a/dlls/prophunt_gamerules.h
+++ b/dlls/prophunt_gamerules.h
@@ -42,6 +42,10 @@ public:
 	virtual BOOL MutatorAllowed(const char *mutator);
 	virtual void DetermineWinner( void );
 	virtual void PlayerKilled( CBasePlayer *pVictim, entvars_t *pKiller, entvars_t *pInflictor );
+	virtual BOOL AllowRuneSpawn( const char *szRune );
+	virtual int WeaponShouldRespawn( CBasePlayerItem *pWeapon );
+	virtual int ItemShouldRespawn( CItem *pItem );
+	virtual int AmmoShouldRespawn( CBasePlayerAmmo *pAmmo );
 
 private:
 	int m_iHuntersRemain;

--- a/dlls/weapons.cpp
+++ b/dlls/weapons.cpp
@@ -793,8 +793,15 @@ int CBasePlayerItem::TakeDamage( entvars_t* pevInflictor, entvars_t* pevAttacker
 			::RadiusDamage( pev->origin, pev, pevAttacker, pev->dmg, pev->dmg  * 2.5, CLASS_NONE, DMG_BURN );
 		}
 
-		Respawn();
-		Kill();
+		if ( g_pGameRules->WeaponShouldRespawn( this ) == GR_WEAPON_RESPAWN_YES )
+		{
+			Respawn();
+			Kill();
+		}
+		else
+		{
+			Kill();
+		}
 	}
 #endif
 	return 1;
@@ -1881,7 +1888,14 @@ int CBasePlayerAmmo::TakeDamage( entvars_t* pevInflictor, entvars_t* pevAttacker
 			::RadiusDamage( pev->origin, pev, pevAttacker, pev->dmg, pev->dmg  * 2.5, CLASS_NONE, DMG_BURN );
 		}
 
-		Respawn();
+		if ( g_pGameRules->AmmoShouldRespawn( this ) == GR_AMMO_RESPAWN_YES )
+		{
+			Respawn();
+		}
+		else
+		{
+			UTIL_Remove( this );
+		}
 	}
 #endif
 	return 1;
@@ -1890,8 +1904,20 @@ int CBasePlayerAmmo::TakeDamage( entvars_t* pevInflictor, entvars_t* pevAttacker
 void CBasePlayerAmmo::Spawn( void )
 {
 	pev->movetype = MOVETYPE_TOSS;
-	pev->solid = SOLID_TRIGGER;
-	UTIL_SetSize(pev, Vector(-16, -16, 0), Vector(16, 16, 16));
+
+	if (g_pGameRules->IsPropHunt())
+	{
+		pev->solid = SOLID_BBOX;
+		pev->health = 1;
+		pev->takedamage = DAMAGE_YES;
+		UTIL_SetSize(pev, VEC_HUMAN_HULL_MIN, VEC_HUMAN_HULL_MAX);
+	}
+	else
+	{
+		pev->solid = SOLID_TRIGGER;
+		UTIL_SetSize(pev, Vector(-16, -16, 0), Vector(16, 16, 16));
+	}
+
 	UTIL_SetOrigin( pev, pev->origin );
 
 	pev->sequence = (pev->body * 2) + floatingweapons.value;
@@ -1908,14 +1934,6 @@ void CBasePlayerAmmo::Spawn( void )
 		pev->health = 1;
 	}
 
-	if (g_pGameRules->IsPropHunt())
-	{
-		pev->solid = SOLID_BBOX;
-		pev->health = 1;
-		pev->takedamage = DAMAGE_YES;
-		UTIL_SetSize(pev, VEC_HUMAN_HULL_MIN, VEC_HUMAN_HULL_MAX);
-	}
-	
 	SetTouch( &CBasePlayerAmmo::DefaultTouch );
 }
 


### PR DESCRIPTION
- Add ricochet label, fix noreload label, support multiple mutator
- Fix items, ammo damage behavior, do not respawn all, and remove runes
- Fix "spectator" in capture the chumtoad mode
- Patch spamming the front flip button.
- Fix empty scoreboard during gungame
- Move gungame levels to scoreboard