### PR TITLE
Improve 999 mutator

### DIFF
--- a/dlls/ctc_gamerules.cpp
+++ b/dlls/ctc_gamerules.cpp
@@ -586,6 +586,9 @@ BOOL CHalfLifeCaptureTheChumtoad::ShouldAutoAim( CBasePlayer *pPlayer, edict_t *
 
 BOOL CHalfLifeCaptureTheChumtoad::MutatorAllowed(const char *mutator)
 {
+	if (strstr(mutator, g_szMutators[MUTATOR_999 - 1]) || atoi(mutator) == MUTATOR_999)
+		return FALSE;
+
 	if (strstr(mutator, g_szMutators[MUTATOR_CHUMXPLODE - 1]) || atoi(mutator) == MUTATOR_CHUMXPLODE)
 		return FALSE;
 

--- a/dlls/triggers.cpp
+++ b/dlls/triggers.cpp
@@ -1009,6 +1009,8 @@ void CBaseTrigger :: HurtTouch ( CBaseEntity *pOther )
 	if (g_AirstrikeActivator && pev->targetname && strstr(STRING(pev->targetname), "strike_pain"))
 	{
 		attacker = g_AirstrikeActivator->pev;
+		if (g_pGameRules->MutatorEnabled(MUTATOR_999))
+			fldmg *= 10;
 	}
 
 	if ( fldmg < 0 )


### PR DESCRIPTION
Fixes the airstrike and disables the 999 mutator on capture the chumtoad