### PR TITLE
Provide gungame steals, fixes from beta 5

### DIFF
--- a/cl_dll/StudioModelRenderer.cpp
+++ b/cl_dll/StudioModelRenderer.cpp
@@ -1484,6 +1484,9 @@ int CStudioModelRenderer::StudioDrawModel( int flags )
 			if (MutatorEnabled(MUTATOR_GOLDENGUNS))
 				m_pCurrentEntity->curstate.skin = SKIN_GOLD;
 
+			if (gHUD.m_Teamplay == GAME_GUNGAME && !strcmp(m_pCurrentEntity->model->name, "models/v_knife.mdl"))
+				m_pCurrentEntity->curstate.skin = SKIN_GOLD;
+
 			if ( pTarget && pTarget->curstate.renderfx == kRenderFxGlowShell )
 			{
 				m_pCurrentEntity->curstate.renderfx = kRenderFxGlowShell;

--- a/cl_dll/hl/hl_weapons.cpp
+++ b/cl_dll/hl/hl_weapons.cpp
@@ -367,6 +367,7 @@ Vector CBaseEntity::FireBulletsPlayer ( ULONG cShots, Vector vecSrc, Vector vecD
 
 extern bool IsShidden( void );
 extern bool IsPropHunt( void );
+extern bool IsGunGame( void );
 
 /*
 =====================

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -1117,3 +1117,8 @@ bool IsPropHunt( void )
 {
 	return gHUD.m_GameMode == GAME_PROPHUNT;
 }
+
+bool IsGunGame( void )
+{
+	return gHUD.m_GameMode == GAME_GUNGAME;
+}

--- a/dlls/chumtoad.cpp
+++ b/dlls/chumtoad.cpp
@@ -519,7 +519,10 @@ void CChumtoadGrenade :: Spawn( void )
 	m_flFieldOfView = 0; // 180 degrees
 
 	if ( pev->owner )
+	{
 		m_hOwner = Instance( pev->owner );
+		pev->euser1 = pev->owner;
+	}
 
 	m_flNextBounceSoundTime = gpGlobals->time;// reset each time a snark is spawned.
 

--- a/dlls/client.cpp
+++ b/dlls/client.cpp
@@ -1313,6 +1313,7 @@ void ClientCommand( edict_t *pEntity )
 		ClientPrint( &pEntity->v, HUD_PRINTCONSOLE, "\"teamplay\"\" - frag on teams\n");
 		ClientPrint( &pEntity->v, HUD_PRINTCONSOLE, "\"mp_ggstartlevel\" - Sets default start level of gun game\n");
 		ClientPrint( &pEntity->v, HUD_PRINTCONSOLE, "\"mp_ggsteallevel\" - Steal levels on fists frag\n");
+		ClientPrint( &pEntity->v, HUD_PRINTCONSOLE, "\"mp_ggfrags\" - How many frags needed for the next level\n");
 		ClientPrint( &pEntity->v, HUD_PRINTCONSOLE, "\"mp_grabsky [0|1]\" - Allow player to grapple and portal to the skybox\n");
 		ClientPrint( &pEntity->v, HUD_PRINTCONSOLE, "\"mp_grapplinghook [0|1]\" - Allow grappling hook on server\n");
 		ClientPrint( &pEntity->v, HUD_PRINTCONSOLE, "\"mp_grapplinghookdeploytime 1.0\" - Time (seconds) when next grappling hook can deploy\n");

--- a/dlls/client.cpp
+++ b/dlls/client.cpp
@@ -1312,6 +1312,7 @@ void ClientCommand( edict_t *pEntity )
 		ClientPrint( &pEntity->v, HUD_PRINTCONSOLE, "\"snowball\"\" - game mode is snowballs and grenades!\n");
 		ClientPrint( &pEntity->v, HUD_PRINTCONSOLE, "\"teamplay\"\" - frag on teams\n");
 		ClientPrint( &pEntity->v, HUD_PRINTCONSOLE, "\"mp_ggstartlevel\" - Sets default start level of gun game\n");
+		ClientPrint( &pEntity->v, HUD_PRINTCONSOLE, "\"mp_ggsteallevel\" - Steal levels on fists frag\n");
 		ClientPrint( &pEntity->v, HUD_PRINTCONSOLE, "\"mp_grabsky [0|1]\" - Allow player to grapple and portal to the skybox\n");
 		ClientPrint( &pEntity->v, HUD_PRINTCONSOLE, "\"mp_grapplinghook [0|1]\" - Allow grappling hook on server\n");
 		ClientPrint( &pEntity->v, HUD_PRINTCONSOLE, "\"mp_grapplinghookdeploytime 1.0\" - Time (seconds) when next grappling hook can deploy\n");

--- a/dlls/crowbar.cpp
+++ b/dlls/crowbar.cpp
@@ -174,6 +174,16 @@ void CCrowbar::PrimaryAttack()
 
 void CCrowbar::SecondaryAttack()
 {
+#ifdef CLIENT_DLL
+	if (IsGunGame())
+#else
+	if (g_pGameRules->IsGunGame())
+#endif
+	{
+		m_flNextSecondaryAttack = UTIL_WeaponTimeBase() + 0.5;
+		return PrimaryAttack();
+	}
+
 	if ( m_pPlayer->pev->waterlevel == 3 )
 	{
 		m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(0.15);

--- a/dlls/dual_wrench.cpp
+++ b/dlls/dual_wrench.cpp
@@ -144,6 +144,16 @@ void CDualWrench::PrimaryAttack()
 
 void CDualWrench::SecondaryAttack()
 {
+#ifdef CLIENT_DLL
+	if (IsGunGame())
+#else
+	if (g_pGameRules->IsGunGame())
+#endif
+	{
+		m_flNextSecondaryAttack = UTIL_WeaponTimeBase() + 0.5;
+		return PrimaryAttack();
+	}
+
 	if ( m_pPlayer->pev->waterlevel == 3 )
 	{
 		m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(0.15);

--- a/dlls/game.cpp
+++ b/dlls/game.cpp
@@ -75,6 +75,7 @@ cvar_t	startwithlives = {"mp_startwithlives","5", FCVAR_SERVER };
 cvar_t	roundfraglimit = {"mp_roundfraglimit","5", FCVAR_SERVER };
 cvar_t	ggstartlevel = {"mp_ggstartlevel","0", FCVAR_SERVER };
 cvar_t	ggsteallevel = {"mp_ggsteallevel","1", FCVAR_SERVER };
+cvar_t	ggfrags = {"mp_ggfrags","1", FCVAR_SERVER };
 cvar_t	spawnitems = {"mp_spawnitems","1", FCVAR_SERVER };
 cvar_t	ctcsecondsforpoint = {"mp_ctcsecondsforpoint","10", FCVAR_SERVER };
 cvar_t	slowbullets = {"sv_slowbullets","0", FCVAR_SERVER };
@@ -742,6 +743,7 @@ void GameDLLInit( void )
 	CVAR_REGISTER(&randomgamemodes);
 	CVAR_REGISTER(&ggstartlevel);
 	CVAR_REGISTER(&ggsteallevel);
+	CVAR_REGISTER(&ggfrags);
 	CVAR_REGISTER(&ctcsecondsforpoint);
 	CVAR_REGISTER(&slowbullets);
 	CVAR_REGISTER(&breakabletime);

--- a/dlls/game.cpp
+++ b/dlls/game.cpp
@@ -74,6 +74,7 @@ cvar_t	roundtimeleft = {"mp_roundtimeleft","0", FCVAR_SERVER | FCVAR_UNLOGGED };
 cvar_t	startwithlives = {"mp_startwithlives","5", FCVAR_SERVER };
 cvar_t	roundfraglimit = {"mp_roundfraglimit","5", FCVAR_SERVER };
 cvar_t	ggstartlevel = {"mp_ggstartlevel","0", FCVAR_SERVER };
+cvar_t	ggsteallevel = {"mp_ggsteallevel","1", FCVAR_SERVER };
 cvar_t	spawnitems = {"mp_spawnitems","1", FCVAR_SERVER };
 cvar_t	ctcsecondsforpoint = {"mp_ctcsecondsforpoint","10", FCVAR_SERVER };
 cvar_t	slowbullets = {"sv_slowbullets","0", FCVAR_SERVER };
@@ -740,6 +741,7 @@ void GameDLLInit( void )
 	CVAR_REGISTER(&roundfraglimit);
 	CVAR_REGISTER(&randomgamemodes);
 	CVAR_REGISTER(&ggstartlevel);
+	CVAR_REGISTER(&ggsteallevel);
 	CVAR_REGISTER(&ctcsecondsforpoint);
 	CVAR_REGISTER(&slowbullets);
 	CVAR_REGISTER(&breakabletime);

--- a/dlls/game.h
+++ b/dlls/game.h
@@ -73,6 +73,7 @@ extern cvar_t   startwithlives;
 extern cvar_t   roundfraglimit;
 extern cvar_t   ggstartlevel;
 extern cvar_t   ggsteallevel;
+extern cvar_t   ggfrags;
 extern cvar_t   ctcsecondsforpoint;
 extern cvar_t   slowbullets;
 extern cvar_t   breakabletime;

--- a/dlls/game.h
+++ b/dlls/game.h
@@ -72,6 +72,7 @@ extern cvar_t   roundtimeleft;
 extern cvar_t   startwithlives;
 extern cvar_t   roundfraglimit;
 extern cvar_t   ggstartlevel;
+extern cvar_t   ggsteallevel;
 extern cvar_t   ctcsecondsforpoint;
 extern cvar_t   slowbullets;
 extern cvar_t   breakabletime;

--- a/dlls/gamerules.cpp
+++ b/dlls/gamerules.cpp
@@ -703,21 +703,21 @@ BOOL CGameRules::WeaponMutators( CBasePlayerWeapon *pWeapon )
 		{
 			if (MutatorEnabled(MUTATOR_ROCKETS))
 			{
-				if (!pWeapon->m_bFired && RANDOM_LONG(0,10) == 2) {
+				if (pWeapon->m_pPlayer->pev->fov == 0 && !pWeapon->m_bFired && RANDOM_LONG(0,10) == 2) {
 					pWeapon->ThrowRocket(FALSE);
 				}
 			}
 			
 			if (MutatorEnabled(MUTATOR_GRENADES))
 			{
-				if (!pWeapon->m_bFired && RANDOM_LONG(0,10) == 2) {
+				if (pWeapon->m_pPlayer->pev->fov == 0 && !pWeapon->m_bFired && RANDOM_LONG(0,10) == 2) {
 					pWeapon->ThrowGrenade(FALSE);
 				}
 			}
 			
 			if (MutatorEnabled(MUTATOR_SNOWBALL))
 			{
-				if (!pWeapon->m_bFired && RANDOM_LONG(0,10) == 2) {
+				if (pWeapon->m_pPlayer->pev->fov == 0 && !pWeapon->m_bFired && RANDOM_LONG(0,10) == 2) {
 					pWeapon->ThrowSnowball(FALSE);
 				}
 			}

--- a/dlls/gungame_gamerules.cpp
+++ b/dlls/gungame_gamerules.cpp
@@ -372,11 +372,44 @@ int CHalfLifeGunGame::IPointsForKill( CBasePlayer *pAttacker, CBasePlayer *pKill
 
 		// Attacker
 		int currentLevel = (int)pAttacker->m_iRoundWins;
-		if (currentLevel < MAXLEVEL)
+		if (currentLevel <= MAXLEVEL)
 		{
 			// Note, frags are increased after this method, so assume +1
 			if ((int)pAttacker->pev->frags+1 >= g_iFrags[currentLevel])
 			{
+				if (!strcmp(g_WeaponId[pAttacker->m_iRoundWins], "snark"))
+					DeactivateItems(pAttacker, "monster_snark");
+				else if (!strcmp(g_WeaponId[pAttacker->m_iRoundWins], "chumtoad"))
+					DeactivateItems(pAttacker, "monster_chumtoad");
+				else if (!strcmp(g_WeaponId[pAttacker->m_iRoundWins], "crossbow"))
+					DeactivateItems(pAttacker, "bolt");
+				else if (!strcmp(g_WeaponId[pAttacker->m_iRoundWins], "gravitygun"))
+					DeactivateItems(pAttacker, "monster_barrel");
+				else if (!strcmp(g_WeaponId[pAttacker->m_iRoundWins], "freezegun"))
+					DeactivateItems(pAttacker, "plasma");
+				else if (!strcmp(g_WeaponId[pAttacker->m_iRoundWins], "handgrenade") ||
+						!strcmp(g_WeaponId[pAttacker->m_iRoundWins], "9mmAR") ||
+						!strcmp(g_WeaponId[pAttacker->m_iRoundWins], "glauncher"))
+					DeactivateItems(pAttacker, "grenade");
+				else if (!strcmp(g_WeaponId[pAttacker->m_iRoundWins], "rpg") ||
+						!strcmp(g_WeaponId[pAttacker->m_iRoundWins], "dual_rpg"))
+					DeactivateItems(pAttacker, "rpg_rocket");
+				else if (!strcmp(g_WeaponId[pAttacker->m_iRoundWins], "hornetgun") ||
+						!strcmp(g_WeaponId[pAttacker->m_iRoundWins], "dual_hornetgun"))
+					DeactivateItems(pAttacker, "hornet");
+				else if (!strcmp(g_WeaponId[pAttacker->m_iRoundWins], "flamethrower") ||
+						!strcmp(g_WeaponId[pAttacker->m_iRoundWins], "dual_flamethrower"))
+					DeactivateItems(pAttacker, "flameball");
+				else if (!strcmp(g_WeaponId[pAttacker->m_iRoundWins], "cannon"))
+				{
+					DeactivateItems(pAttacker, "flak");
+					DeactivateItems(pAttacker, "flak_bomb");
+				}
+				else if (!strcmp(g_WeaponId[pAttacker->m_iRoundWins], "tripmine"))
+					DeactivateItems(pAttacker, "monster_tripmine");
+				else if (!strcmp(g_WeaponId[pAttacker->m_iRoundWins], "satchel"))
+					DeactivateSatchels(pAttacker);
+
 				pAttacker->m_iRoundWins += 1;
 				int newLevel = (int)pAttacker->m_iRoundWins;
 				int voiceId = 0;

--- a/dlls/gungame_gamerules.cpp
+++ b/dlls/gungame_gamerules.cpp
@@ -156,7 +156,7 @@ void CHalfLifeGunGame::Think( void )
 		return;
 	}
 
-	if ( ggstartlevel.value < 0 || ggstartlevel.value > MAXLEVEL-1)
+	if ( ggstartlevel.value < 0 || ggstartlevel.value > MAXLEVEL)
 	{
 		g_engfuncs.pfnCvar_DirectSet( &ggstartlevel, UTIL_VarArgs( "%i", 0 ) );
 	}
@@ -482,8 +482,8 @@ void CHalfLifeGunGame::PlayerSpawn( CBasePlayer *pPlayer )
 
 	// In full game, go deep with negative deaths but in short game, pin to lowest level
 	if (ggstartlevel.value > 1 && pPlayer->m_iRoundWins < ggstartlevel.value) {
-		pPlayer->m_iRoundWins = (int)ggstartlevel.value;
-		pPlayer->pev->frags = g_iFrags[(int)ggstartlevel.value - 1];
+		pPlayer->m_iRoundWins = (int)ggstartlevel.value - 1;
+		pPlayer->pev->frags = g_iFrags[(int)ggstartlevel.value - 2];
 	}
 
 	MESSAGE_BEGIN( MSG_ALL, gmsgScoreInfo );

--- a/dlls/gungame_gamerules.cpp
+++ b/dlls/gungame_gamerules.cpp
@@ -35,10 +35,10 @@ extern int gmsgObjective;
 extern int gmsgRoundTime;
 extern int gmsgShowTimer;
 
-#define MAXLEVEL 47
+#define MAXLEVEL 46
 int g_iFrags[MAXLEVEL+1] = { 1, 3, 5, 6, 9, 12, 15, 18, 21, 26, 29, 30, 31, 32, 33, 34, 35,
 							36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
-							52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65 };
+							52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 65 };
 const char *g_WeaponId[MAXLEVEL+1] = 
 {
 	// hand
@@ -91,7 +91,6 @@ const char *g_WeaponId[MAXLEVEL+1] =
 	"dual_wrench",
 	"wrench",
 	"crowbar",
-	"fists",
 	"knife",
 	"Winner"
 };

--- a/dlls/gungame_gamerules.cpp
+++ b/dlls/gungame_gamerules.cpp
@@ -477,12 +477,9 @@ const char *ammoList[] =
 
 BOOL CHalfLifeGunGame::IsAllowedToSpawn( CBaseEntity *pEntity )
 {
-	if (strncmp(STRING(pEntity->pev->classname), "weapon_", 7) == 0)
+	if (!FBitSet(pEntity->pev->spawnflags, SF_GIVEITEM) && strncmp(STRING(pEntity->pev->classname), "weapon_", 7) == 0)
 	{
-		CBaseEntity *p = CBaseEntity::Create((char *)ammoList[RANDOM_LONG(0, ARRAYSIZE(ammoList)-1)], pEntity->pev->origin, pEntity->pev->angles, pEntity->pev->owner);
-		if (FBitSet(pEntity->pev->spawnflags, SF_GIVEITEM))
-			if (p)
-				p->pev->spawnflags |= SF_NORESPAWN;
+		CBaseEntity::Create((char *)ammoList[RANDOM_LONG(0, ARRAYSIZE(ammoList)-1)], pEntity->pev->origin, pEntity->pev->angles, pEntity->pev->owner);
 		return FALSE;
 	}
 

--- a/dlls/gungame_gamerules.cpp
+++ b/dlls/gungame_gamerules.cpp
@@ -294,6 +294,15 @@ int CHalfLifeGunGame::IPointsForKill( CBasePlayer *pAttacker, CBasePlayer *pKill
 {
 	if (m_fGoToIntermission == 0 && pAttacker && pKilled)
 	{
+		BOOL isOffhand = (gMultiDamage.pEntity == pKilled && (gMultiDamage.type & DMG_PUNCH || gMultiDamage.type & DMG_KICK) && 
+						(pAttacker->pev->flags & FL_CLIENT) && gMultiDamage.time > gpGlobals->time - 0.5);
+		if (isOffhand)
+			return 0;
+
+		BOOL isWeapon = pAttacker->m_pActiveItem && !strcmp(pAttacker->m_pActiveItem->pszName(), "weapon_fists") && gMultiDamage.type & DMG_PUNCH;
+		if (isWeapon)
+			return 0;
+
 		// Attacker
 		int currentLevel = (int)pAttacker->m_iRoundWins;
 		if (currentLevel < MAXLEVEL)

--- a/dlls/gungame_gamerules.cpp
+++ b/dlls/gungame_gamerules.cpp
@@ -536,13 +536,6 @@ void CHalfLifeGunGame::PlayerSpawn( CBasePlayer *pPlayer )
 	sprintf(weapon, "%s%s", "weapon_", g_WeaponId[currentLevel]);
 	if (!pPlayer->HasNamedPlayerItem(weapon))
 		pPlayer->GiveNamedItem(STRING(ALLOC_STRING(weapon)));
-	pPlayer->GiveAmmo(AMMO_GLOCKCLIP_GIVE * 4, "9mm", _9MM_MAX_CARRY);
-	pPlayer->GiveAmmo(AMMO_357BOX_GIVE * 4, "357", _357_MAX_CARRY);
-	pPlayer->GiveAmmo(AMMO_BUCKSHOTBOX_GIVE * 4, "buckshot", BUCKSHOT_MAX_CARRY);
-	pPlayer->GiveAmmo(AMMO_CROSSBOWCLIP_GIVE * 4, "bolts", BOLT_MAX_CARRY);
-	pPlayer->GiveAmmo(AMMO_M203BOX_GIVE * 2, "ARgrenades", M203_GRENADE_MAX_CARRY);
-	pPlayer->GiveAmmo(AMMO_RPGCLIP_GIVE * 2, "rockets", ROCKET_MAX_CARRY);
-	pPlayer->GiveAmmo(AMMO_URANIUMBOX_GIVE * 4, "uranium", URANIUM_MAX_CARRY);
 
 	ClientPrint(pPlayer->pev, HUD_PRINTTALK, UTIL_VarArgs("[GunGame]: You need %d frags to reach level %s.\n",
 		g_iFrags[currentLevel] - ((int)pPlayer->pev->frags), g_WeaponId[currentLevel+1]));

--- a/dlls/knife.cpp
+++ b/dlls/knife.cpp
@@ -179,6 +179,16 @@ void CKnife::PrimaryAttack()
 
 void CKnife::SecondaryAttack()
 {
+#ifdef CLIENT_DLL
+	if (IsGunGame())
+#else
+	if (g_pGameRules->IsGunGame())
+#endif
+	{
+		m_flNextSecondaryAttack = UTIL_WeaponTimeBase() + 0.5;
+		return PrimaryAttack();
+	}
+
 	if ( m_fInZoom )
 	{
 		return;

--- a/dlls/multiplay_gamerules.cpp
+++ b/dlls/multiplay_gamerules.cpp
@@ -2001,7 +2001,7 @@ void CHalfLifeMultiplay :: PlayerKilled( CBasePlayer *pVictim, entvars_t *pKille
 	{
 		DeactivateSatchels( pVictim );
 		if (g_pGameRules->FAllowMonsters())
-			DeactivateAssassins( pVictim );
+			DeactivateItems(pVictim, "monster_human_assassin");
 	}
 	DeactivatePortals( pVictim );
 #endif

--- a/dlls/multiplay_gamerules.cpp
+++ b/dlls/multiplay_gamerules.cpp
@@ -960,7 +960,7 @@ void CHalfLifeMultiplay::InsertClientsIntoArena(float fragcount)
 				WRITE_BYTE( ENTINDEX(plr->edict()) );
 				WRITE_SHORT( plr->pev->frags = fragcount );
 				WRITE_SHORT( plr->m_iDeaths = 0 );
-				WRITE_SHORT( plr->m_iRoundWins );
+				WRITE_SHORT( g_GameMode != GAME_GUNGAME ? plr->m_iRoundWins : plr->m_iRoundWins + 1 );
 				WRITE_SHORT( GetTeamIndex( plr->m_szTeamName ) + 1 );
 			MESSAGE_END();
 			plr->m_iAssists = 0;
@@ -1098,7 +1098,7 @@ void CHalfLifeMultiplay::SuckAllToSpectator( void )
 				WRITE_BYTE( ENTINDEX(pPlayer->edict()) );
 				WRITE_SHORT( pPlayer->pev->frags = 0 );
 				WRITE_SHORT( pPlayer->m_iDeaths = 0 );
-				WRITE_SHORT( pPlayer->m_iRoundWins );
+				WRITE_SHORT( g_GameMode != GAME_GUNGAME ? pPlayer->m_iRoundWins : pPlayer->m_iRoundWins + 1 );
 				WRITE_SHORT( GetTeamIndex( pPlayer->m_szTeamName ) + 1 );
 			MESSAGE_END();
 
@@ -1520,7 +1520,7 @@ void CHalfLifeMultiplay :: ClientDisconnected( edict_t *pClient )
 					WRITE_BYTE( ENTINDEX(pPlayer->edict()) );
 					WRITE_SHORT( pPlayer->pev->frags );
 					WRITE_SHORT( pPlayer->m_iDeaths );
-					WRITE_SHORT( pPlayer->m_iRoundWins );
+					WRITE_SHORT( g_GameMode != GAME_GUNGAME ? pPlayer->m_iRoundWins : pPlayer->m_iRoundWins + 1 );
 					WRITE_SHORT( GetTeamIndex( pPlayer->m_szTeamName ) + 1 );
 				MESSAGE_END();
 			}
@@ -1975,7 +1975,7 @@ void CHalfLifeMultiplay :: PlayerKilled( CBasePlayer *pVictim, entvars_t *pKille
 		WRITE_BYTE( ENTINDEX(pVictim->edict()) );
 		WRITE_SHORT( pVictim->pev->frags );
 		WRITE_SHORT( pVictim->m_iDeaths );
-		WRITE_SHORT( pVictim->m_iRoundWins );
+		WRITE_SHORT( g_GameMode != GAME_GUNGAME ? pVictim->m_iRoundWins : pVictim->m_iRoundWins + 1 );
 		WRITE_SHORT( GetTeamIndex( pVictim->m_szTeamName ) + 1 );
 	MESSAGE_END();
 
@@ -1989,7 +1989,7 @@ void CHalfLifeMultiplay :: PlayerKilled( CBasePlayer *pVictim, entvars_t *pKille
 			WRITE_BYTE( ENTINDEX(PK->edict()) );
 			WRITE_SHORT( PK->pev->frags );
 			WRITE_SHORT( PK->m_iDeaths );
-			WRITE_SHORT( PK->m_iRoundWins );
+			WRITE_SHORT( g_GameMode != GAME_GUNGAME ? PK->m_iRoundWins : PK->m_iRoundWins + 1 );
 			WRITE_SHORT( GetTeamIndex( PK->m_szTeamName) + 1 );
 		MESSAGE_END();
 

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -1847,7 +1847,7 @@ void CBasePlayer::StartObserver( Vector vecPosition, Vector vecViewAngle )
 	// Remove all items left by the player
 	DeactivateSatchels(this);
 	if (g_pGameRules->FAllowMonsters())
-		DeactivateAssassins(this);
+		DeactivateItems(this, "monster_human_assassin");
 	DeactivatePortals(this);
 	DeactivateDecoys(this);
 

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -5685,7 +5685,12 @@ void CBasePlayer::StartForceGrab( void )
 				EMIT_SOUND(edict(), CHAN_VOICE, "odetojoy.wav", 1, ATTN_NORM);
 
 				ClientPrint(plr->pev, HUD_PRINTCENTER, "Your weapon has been taken!\n");
-				plr->DropPlayerItem("", FALSE, FALSE);
+				if (plr->m_pActiveItem->m_iId < 32)
+					plr->pev->weapons &= ~(1<<plr->m_pActiveItem->m_iId);
+				else
+					plr->m_iWeapons2 &= ~(1<<(plr->m_pActiveItem->m_iId - 32));
+				plr->m_pActiveItem->SetThink( &CBasePlayerItem::DestroyItem );
+				plr->m_pActiveItem->pev->nextthink = gpGlobals->time + 0.1;
 			}
 		}
 	}

--- a/dlls/satchel.cpp
+++ b/dlls/satchel.cpp
@@ -607,11 +607,11 @@ void DeactivateSatchels( CBasePlayer *pOwner )
 	}
 }
 
-void DeactivateAssassins( CBasePlayer *pOwner )
+void DeactivateItems( CBasePlayer *pOwner, const char *item )
 {
 	edict_t *pFind; 
 
-	pFind = FIND_ENTITY_BY_CLASSNAME( NULL, "monster_human_assassin" );
+	pFind = FIND_ENTITY_BY_CLASSNAME( NULL, item );
 
 	while ( !FNullEnt( pFind ) )
 	{
@@ -619,14 +619,15 @@ void DeactivateAssassins( CBasePlayer *pOwner )
 
 		if ( pEnt )
 		{
-			if ( pEnt->pev->owner == pOwner->edict() )
+			if ( pEnt->pev->owner == pOwner->edict() ||
+				 pEnt->pev->euser1 == pOwner->edict() )
 			{
 				pEnt->pev->solid = SOLID_NOT;
 				UTIL_Remove( pEnt );
 			}
 		}
 
-		pFind = FIND_ENTITY_BY_CLASSNAME( pFind, "monster_human_assassin" );
+		pFind = FIND_ENTITY_BY_CLASSNAME( pFind, item );
 	}
 }
 

--- a/dlls/squeakgrenade.cpp
+++ b/dlls/squeakgrenade.cpp
@@ -140,7 +140,10 @@ void CSqueakGrenade :: Spawn( void )
 	m_flFieldOfView = 0; // 180 degrees
 
 	if ( pev->owner )
+	{
 		m_hOwner = Instance( pev->owner );
+		pev->euser1 = pev->owner;
+	}
 
 	m_flNextBounceSoundTime = gpGlobals->time;// reset each time a snark is spawned.
 

--- a/dlls/weapons.cpp
+++ b/dlls/weapons.cpp
@@ -2021,6 +2021,8 @@ int CBasePlayerWeapon::ExtractAmmo( CBasePlayerWeapon *pWeapon )
 
 	if ( pszAmmo1() != NULL )
 	{
+		if (g_pGameRules->IsGunGame())
+			m_iDefaultAmmo = m_iDefaultAmmo * 4;
 		// blindly call with m_iDefaultAmmo. It's either going to be a value or zero. If it is zero,
 		// we only get the ammo in the weapon's clip, which is what we want. 
 		iReturn = pWeapon->AddPrimaryAmmo( m_iDefaultAmmo, (char *)pszAmmo1(), iMaxClip(), iMaxAmmo1() );
@@ -2029,7 +2031,10 @@ int CBasePlayerWeapon::ExtractAmmo( CBasePlayerWeapon *pWeapon )
 
 	if ( pszAmmo2() != NULL )
 	{
-		iReturn = pWeapon->AddSecondaryAmmo( 0, (char *)pszAmmo2(), iMaxAmmo2() );
+		int count = 0;
+		if (g_pGameRules->IsGunGame())
+			count = 2;
+		iReturn = pWeapon->AddSecondaryAmmo( count, (char *)pszAmmo2(), iMaxAmmo2() );
 	}
 
 	return iReturn;

--- a/dlls/weapons.cpp
+++ b/dlls/weapons.cpp
@@ -3261,7 +3261,7 @@ void CBasePlayerWeapon::ThrowWeapon( BOOL holdingSomething )
 
 	if (g_pGameRules->IsGunGame() || g_pGameRules->IsInstagib())
 	{
-		ClientPrint(m_pPlayer->pev, HUD_PRINTCENTER, "Forcegrab disabled in this gamemode.");
+		ClientPrint(m_pPlayer->pev, HUD_PRINTCENTER, "Throw weapon is disabled in this gamemode.");
 		m_pPlayer->m_fOffhandTime = gpGlobals->time + 0.5;
 		return;
 	}

--- a/dlls/weapons.h
+++ b/dlls/weapons.h
@@ -635,6 +635,7 @@ public:
 
 #ifdef CLIENT_DLL
 bool bIsMultiplayer ( void );
+bool IsGunGame ( void );
 void LoadVModel ( char *szViewModel, CBasePlayer *m_pPlayer );
 #endif
 

--- a/dlls/weapons.h
+++ b/dlls/weapons.h
@@ -21,7 +21,7 @@ class CBasePlayer;
 extern int gmsgWeapPickup;
 
 void DeactivateSatchels( CBasePlayer *pOwner );
-void DeactivateAssassins( CBasePlayer *pOwner );
+void DeactivateItems( CBasePlayer *pOwner, const char *item );
 void DeactivatePortals( CBasePlayer *pOwner );
 void DeactivateDecoys( CBasePlayer *pOwner );
 

--- a/dlls/wrench.cpp
+++ b/dlls/wrench.cpp
@@ -145,6 +145,16 @@ void CWrench::PrimaryAttack()
 
 void CWrench::SecondaryAttack()
 {
+#ifdef CLIENT_DLL
+	if (IsGunGame())
+#else
+	if (g_pGameRules->IsGunGame())
+#endif
+	{
+		m_flNextSecondaryAttack = UTIL_WeaponTimeBase() + 0.5;
+		return PrimaryAttack();
+	}
+
 	if ( m_pPlayer->pev->waterlevel == 3 )
 	{
 		m_flNextPrimaryAttack = m_flNextSecondaryAttack = GetNextAttackDelay(0.15);


### PR DESCRIPTION
- Support steals with ggsteallevel
- Enable the golden knife at the end of the game
- Immediately remove entities when weapon upgrades
- Improve weapon upgrades with server-defined ggfrags amount
- Disable throwable weapons
- Disable weapon spawn mutators when zoomed in
- Increase initial weapon ammo in gungame
- Fix forcegrab in gungame
- Fix ggstartlevel so it matches the correct level
- Disable scoring on punch or kicks unless stealing is enabled (punch only)